### PR TITLE
fixes netbox exception when there are no interfaces or ports

### DIFF
--- a/netbox_device_view/utils.py
+++ b/netbox_device_view/utils.py
@@ -61,7 +61,7 @@ def prepare(obj):
             ports_chassis = process_ports(
                 ConsolePort.objects.filter(device_id=obj.id),
                 ports_chassis,
-                list(ports_chassis.keys())[0],
+                obj.name,
             )
         else:
             for member in obj.virtual_chassis.members.all():


### PR DESCRIPTION
Hi @peterbaumert ! 

I noticed when there are no interfaces that a NetBox exception can occur on non-chassis devices, proposed fix should address this. 

P.S. I'm working on additional port views and a larger port layout option in another branch as well, more to come!

