### PR TITLE
feat: add YAML layout system with CSS Grid renderer

### DIFF
--- a/.devcontainer/docker-entrypoint-dev.sh
+++ b/.devcontainer/docker-entrypoint-dev.sh
@@ -5,11 +5,6 @@ echo "Installing netbox-device-view in editable mode..."
 uv pip install --python /opt/netbox/venv/bin/python3 --no-cache -e /opt/code/netbox-device-view
 echo "Plugin installed."
 
-echo "Installing pre-commit hooks..."
-uv tool install pre-commit
-pre-commit install --git-dir /opt/code/netbox-device-view/.git --work-tree /opt/code/netbox-device-view
-echo "Pre-commit hooks installed."
-
 # Enable hot-reload in Granian (used by launch-netbox.sh via ${GRANIAN_EXTRA_ARGS[@]})
 export GRANIAN_EXTRA_ARGS="--reload"
 

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ views:
                 prefix: "gigabitethernet0-"
                 start: 1
                 count: 12
-                pattern: odd
+                pattern: top-odd
             - sequence:
                 kind: interface
                 prefix: "gigabitethernet0-"
                 start: 13
                 count: 12
-                pattern: odd
+                pattern: top-odd
       - spacer: 4
 
 variants:
@@ -138,19 +138,19 @@ variants:
                 prefix: "gigabitethernet0-"
                 start: 1
                 count: 12
-                pattern: odd
+                pattern: top-odd
             - sequence:
                 kind: interface
                 prefix: "gigabitethernet0-"
                 start: 13
                 count: 12
-                pattern: odd
+                pattern: top-odd
             - sequence:
                 kind: interface
                 prefix: "tengigabitethernet1-"
                 start: 1
                 count: 8
-                pattern: odd
+                pattern: top-odd
 ```
 
 See [`docs/yaml-layout-schema.md`](docs/yaml-layout-schema.md) for the full schema reference and [`examples/yaml/`](examples/yaml/) for ready-made YAML files.

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ PLUGINS_CONFIG = {
 
 ## How It Works
 
-For each **Device Type** you create a **DeviceView** object (at *Plugins → Device Views → Add*) containing a CSS `grid-template-areas` definition. When you visit a device of that type, the plugin renders every interface and port as a clickable cell in the grid.
+For each **Device Type** you create a **DeviceView** object (at *Plugins → Device Views → Add*) with either a **YAML layout** or a raw **CSS layout**. When you visit a device of that type, the plugin renders every interface and port as a clickable cell in the grid.
 
 ### Port/Interface name → CSS grid-area name
 
-The plugin derives a `stylename` for each interface and port, which must match the area names in your CSS:
+The plugin derives a `stylename` for each interface and port:
 
 | Interface name | Stylename |
 |----------------|-----------|
@@ -82,54 +82,105 @@ The plugin derives a `stylename` for each interface and port, which must match t
 - Purely numeric stylenames are prefixed with `p`
 - Virtual and LAG interfaces are skipped
 
-### CSS layout format
+---
 
-The `grid_template_area` field stores raw CSS. The grid has **32 columns** and uses **20 px cells**.
+## Layout formats
 
-Placeholder names:
-- `x` — leading empty cell
-- `z` — trailing empty cell
-- `s0`–`s99` — interior spacer cells
+A DeviceView supports two layout formats. **YAML is preferred** — it is easier to write, validate, and maintain. Legacy CSS is still fully supported for backward compatibility.
 
-Example for a Cisco C9300-24T with an optional 8x 10G module (more in the [`examples/`](examples/) folder):
+### YAML layout (recommended)
+
+Fill the **YAML Layout** field with a YAML document describing the device layout. The plugin compiles it to CSS at render time.
+
+Example for a Cisco C9300-24T with an optional 8x 10G expansion module:
+
+```yaml
+version: 1
+
+meta:
+  description: "Cisco Catalyst 9300-24T"
+
+canvas:
+  columns: 32
+  rows: 2
+
+views:
+  front:
+    rows:
+      - blank: 14
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 1
+                count: 12
+                pattern: odd
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 13
+                count: 12
+                pattern: odd
+      - spacer: 4
+
+variants:
+  C9300-NM-8X:
+    match: module
+    rows:
+      - blank: 14
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 1
+                count: 12
+                pattern: odd
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 13
+                count: 12
+                pattern: odd
+            - sequence:
+                kind: interface
+                prefix: "tengigabitethernet1-"
+                start: 1
+                count: 8
+                pattern: odd
+```
+
+See [`docs/yaml-layout-schema.md`](docs/yaml-layout-schema.md) for the full schema reference and [`examples/yaml/`](examples/yaml/) for ready-made YAML files.
+
+### CSS layout (legacy)
+
+Fill the **Grid Template Area** field with raw CSS. The grid has **32 columns** and uses **20 px cells**.
+
+Placeholder names: `x` — leading blank, `z` — trailing blank, `s0`–`s99` — interior spacers.
 
 ```css
 /* C9300-24T */
 .deviceview.area {
-	grid-template-areas:
-	"x x x x x x x x x x x x x x gigabitethernet0-1 gigabitethernet0-3 gigabitethernet0-5 gigabitethernet0-7 gigabitethernet0-9 gigabitethernet0-11 s0 gigabitethernet0-13 gigabitethernet0-15 gigabitethernet0-17 gigabitethernet0-19 gigabitethernet0-21 gigabitethernet0-23 z z z z z"
-	"x x x x x x x x x x x x x x gigabitethernet0-2 gigabitethernet0-4 gigabitethernet0-6 gigabitethernet0-8 gigabitethernet0-10 gigabitethernet0-12 s0 gigabitethernet0-14 gigabitethernet0-16 gigabitethernet0-18 gigabitethernet0-20 gigabitethernet0-22 gigabitethernet0-24 z z z z z";
-}
-
-/* C9300-24T with C9300-NM-8X */
-.deviceview.moduleC9300-NM-8X.area {
-	grid-template-areas:
-	"x x x x x x x x x x x x x x gigabitethernet0-1 gigabitethernet0-3 gigabitethernet0-5 gigabitethernet0-7 gigabitethernet0-9 gigabitethernet0-11 s0 gigabitethernet0-13 gigabitethernet0-15 gigabitethernet0-17 gigabitethernet0-19 gigabitethernet0-21 gigabitethernet0-23 s1 tengigabitethernet1-1 tengigabitethernet1-3 tengigabitethernet1-5 tengigabitethernet1-7"
-	"x x x x x x x x x x x x x x gigabitethernet0-2 gigabitethernet0-4 gigabitethernet0-6 gigabitethernet0-8 gigabitethernet0-10 gigabitethernet0-12 s0 gigabitethernet0-14 gigabitethernet0-16 gigabitethernet0-18 gigabitethernet0-20 gigabitethernet0-22 gigabitethernet0-24 s1 tengigabitethernet1-2 tengigabitethernet1-4 tengigabitethernet1-6 tengigabitethernet1-8";
+    grid-template-areas:
+    "x x x x x x x x x x x x x x gigabitethernet0-1 gigabitethernet0-3 ... z z z z z"
+    "x x x x x x x x x x x x x x gigabitethernet0-2 gigabitethernet0-4 ... z z z z z";
 }
 ```
+
+See [`examples/`](examples/) for ready-made CSS files.
+
+> **Precedence:** if a DeviceView has a YAML layout, it is used and the CSS field is ignored.
 
 ### Module variants
 
-If a device has an installed module, an additional CSS class matching the module model is added. Define a separate rule to override the layout when that module is present (see the example above).
+When a device has an installed module, an extra CSS class matching the module model is added to the device div. In YAML, declare a `variants:` block. In CSS, add a `.deviceview.module{ModelName}.area` rule.
 
 ### Virtual Chassis
 
-For virtual chassis devices, each member's CSS areas are scoped with a `.d{vc_position}` suffix automatically. Define per-member layouts using those suffixes:
-
-```css
-/* Member at vc_position 1 */
-.deviceview.area.d1 {
-    grid-template-areas: "gigabitethernet0-1 gigabitethernet0-2";
-}
-
-/* Member at vc_position 2 */
-.deviceview.area.d2 {
-    grid-template-areas: "gigabitethernet0-1 gigabitethernet0-2";
-}
-```
-
-More ready-made layouts for Cisco C2960X, C8300, C9200, C9300, generic patch panels, and Ubiquiti switches are in the [`examples/`](examples/) folder.
+For virtual chassis devices, each member's CSS areas are scoped with a `.d{vc_position}` suffix automatically. YAML-rendered CSS is scoped the same way.
 
 ## Troubleshooting
 

--- a/docs/yaml-layout-schema.md
+++ b/docs/yaml-layout-schema.md
@@ -58,16 +58,17 @@ Each entry in `rows:` is one of:
     start: 1              # first port number (default: 1)
     count: 24             # how many ports
     step: 1               # increment between port numbers (default: 1)
-    pattern: odd          # odd | even | all  (default: odd)
+    pattern: top-odd      # top-odd | top-even | all  (default: top-odd)
+    row: 1                # for pattern: all only — target row (default: 1)
 ```
 
 **Patterns:**
 
 | Pattern | Behaviour |
 |---------|-----------|
-| `odd`   | Odd-numbered ports → row 1; even-numbered ports → row 2 (standard 2U Cisco style) |
-| `even`  | Even-numbered ports → row 1; odd-numbered ports → row 2 (inverted) |
-| `all`   | All ports in a single row (patch-panel style) |
+| `top-odd`   | Odd-numbered ports → row 1 (top); even-numbered ports → row 2 (standard 2U Cisco style) |
+| `top-even`  | Even-numbered ports → row 1 (top); odd-numbered ports → row 2 (inverted) |
+| `all`   | All ports in a single row (patch-panel style); use `row: 2` to place them in the bottom row |
 
 #### `group` — multiple sequences separated by spacers
 

--- a/docs/yaml-layout-schema.md
+++ b/docs/yaml-layout-schema.md
@@ -1,0 +1,256 @@
+# YAML Layout Schema Reference
+
+This document describes the full YAML schema for `netbox-device-view` layouts.
+
+## Top-level structure
+
+```yaml
+version: 1          # required — must be 1
+
+meta:               # optional
+  description: "Human-readable name"
+  background: "#d9d9d9"   # default background for all views
+
+canvas:             # optional — defaults shown
+  columns: 32       # total grid columns
+  rows: 2           # total grid rows
+  cell_size: 20     # px per cell (reserved for future SVG renderer)
+                    # set to 0 to enable patch-panel auto sizing
+
+views:              # required — at least one of: front, rear
+  front: <view>
+  rear:  <view>
+
+variants:           # optional — module overlays
+  "<Module Model Name>": <variant>
+```
+
+---
+
+## View definition
+
+A view defines the layout for one face (front or rear). It uses either `rows:` (high-level, recommended) or `elements:` (explicit coordinates).
+
+```yaml
+views:
+  front:
+    background: "#000"    # optional — overrides meta.background for this view
+    canvas:               # optional — override canvas for this view only
+      columns: 24
+    rows:                 # ordered list of row entries (see below)
+      - ...
+    # OR
+    elements:             # explicit element list with at:/span: (see below)
+      - ...
+    copy_from: front      # copy another view's rows as a base (then override)
+```
+
+### Row entries
+
+Each entry in `rows:` is one of:
+
+#### `sequence` — expand a numbered port range
+
+```yaml
+- sequence:
+    kind: port            # port | interface | console-port | power-port | module-slot
+    prefix: "port-"       # string prepended to each port number
+    start: 1              # first port number (default: 1)
+    count: 24             # how many ports
+    step: 1               # increment between port numbers (default: 1)
+    pattern: odd          # odd | even | all  (default: odd)
+```
+
+**Patterns:**
+
+| Pattern | Behaviour |
+|---------|-----------|
+| `odd`   | Odd-numbered ports → row 1; even-numbered ports → row 2 (standard 2U Cisco style) |
+| `even`  | Even-numbered ports → row 1; odd-numbered ports → row 2 (inverted) |
+| `all`   | All ports in a single row (patch-panel style) |
+
+#### `group` — multiple sequences separated by spacers
+
+```yaml
+- group:
+    spacer: 1             # number of spacer columns between sections
+    sections:
+      - sequence: ...
+      - sequence: ...
+      - elements: [...]   # inline explicit elements
+      - blank: 2          # insert N blank columns in this section
+```
+
+#### `spacer` — insert N spacer columns (spanning all rows)
+
+```yaml
+- spacer: 1
+```
+
+Spacers use auto-generated keys (`s1`, `s2`, …). They appear as empty visual gaps.
+
+#### `blank` — insert N blank decorative columns (spanning all rows)
+
+```yaml
+- blank: 14
+```
+
+Blanks also use auto-generated keys (`x1`, `x2`, …). Used for the left-hand chassis art on switches.
+
+#### `elements` — explicit list for a single row
+
+```yaml
+- elements:
+    - kind: interface
+      key: "tengigabitethernet0-1"
+    - kind: blank
+      key: "y"
+    - "some-port-key"     # shorthand string: kind inferred from key name
+```
+
+---
+
+## Explicit element format (`elements:` at view level)
+
+For precise control, skip `rows:` and use `elements:` directly with explicit coordinates:
+
+```yaml
+views:
+  front:
+    elements:
+      - kind: port
+        key: "port-1"
+        at:
+          row: 1
+          col: 1
+        span:
+          rows: 1       # default: 1
+          cols: 1       # default: 1
+        label: "Optional display label"
+        face: both      # front | rear | both  (default: both)
+        css_classes: [] # extra CSS classes
+
+      - kind: spacer
+        at: {row: 1, col: 2}
+        span: {rows: 2, cols: 1}
+```
+
+`key` is required for port-like kinds. For `spacer` and `blank`, it is auto-generated if omitted.
+
+**Kind values:**
+
+| YAML value | Meaning |
+|------------|---------|
+| `port` | Front or rear port |
+| `interface` | Network interface |
+| `console-port` | Console port |
+| `power-port` | Power port |
+| `module-slot` | Module / expansion slot |
+| `spacer` | Visual gap (rendered as empty cell) |
+| `blank` | Decorative filler cell |
+| `label` | Text label (future use) |
+
+---
+
+## Variant definition
+
+Variants define an alternative layout applied when a specific module model is installed.
+
+```yaml
+variants:
+  "C9300-NM-8X":          # must match the NetBox module model name exactly
+    match: module          # always "module" for now
+    view: front            # which view this variant applies to (default: front)
+    rows:                  # full row definition for this variant
+      - ...
+    elements:              # OR flat elements
+      - ...
+```
+
+The rendered CSS for a variant is a *full replacement* of the base view's grid (not a delta). To include the base ports, re-specify them in the variant's `rows:` block alongside the new module ports.
+
+---
+
+## Patch panels
+
+Patch panels have distinct front and rear views. Use `cell_size: 0` on the canvas to enable `grid-auto-rows: auto; grid-auto-columns: auto` sizing, and `pattern: all` for single-row sequences.
+
+```yaml
+version: 1
+meta:
+  description: "Generic 24-port UTP Patch Panel"
+canvas:
+  columns: 28
+  rows: 1
+  cell_size: 0      # enables patch-panel auto sizing
+
+views:
+  front:
+    rows:
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 1
+                count: 6
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 7
+                count: 6
+                pattern: all
+            # ... more sections
+
+  rear:
+    copy_from: front    # identical layout
+```
+
+---
+
+## `copy_from`
+
+A view can inherit another view's element list as a starting point:
+
+```yaml
+views:
+  front:
+    rows: [...]
+  rear:
+    copy_from: front    # starts with front's elements
+    # additional elements here override by key
+```
+
+---
+
+## CSS output conventions
+
+The YAML renderer produces CSS equivalent to the legacy hand-written format:
+
+| Scenario | CSS selector |
+|----------|-------------|
+| Single-face device (switch, router) | `.deviceview.area` |
+| Patch panel front | `.deviceview.area.dFront` |
+| Patch panel rear | `.deviceview.area.dRear` |
+| Module variant | `.deviceview.module{ModelName}.area` |
+
+---
+
+## Examples
+
+Ready-made YAML layouts are in [`examples/yaml/`](../examples/yaml/):
+
+| File | Device |
+|------|--------|
+| `Cisco/C9300-24T.yaml` | Cisco Catalyst 9300-24T (+ C9300-NM-8X variant) |
+| `Cisco/C2960X-24TD-L.yaml` | Cisco Catalyst 2960X-24TD-L |
+| `Cisco/C8300-2N2S-4T2X.yaml` | Cisco C8300-2N2S-4T2X |
+| `Cisco/FPR1120-NGFW-K9.yaml` | Cisco Firepower FPR1120 |
+| `Generic/24-ports-UTP-Patchpanel.yaml` | Generic 24-port UTP patch panel |
+| `Generic/48-ports-UTP-Patchpanel.yaml` | Generic 48-port UTP patch panel |
+| `Generic/24xLC-Patchpanel.yaml` | Generic 24xLC fiber patch panel |
+| `Generic/SC-24-port_Fiber_Patch_Panel.yaml` | Generic SC 24-port fiber patch panel |
+| `Generic/LC-48-port-Fiber-Patchpanel.yaml` | Generic LC 48-port fiber patch panel |
+| `Ubiquiti/USW-Enterprise-24-PoE.yaml` | Ubiquiti USW-Enterprise-24-PoE |

--- a/examples/yaml/Cisco/C2960X-24TD-L.yaml
+++ b/examples/yaml/Cisco/C2960X-24TD-L.yaml
@@ -4,7 +4,7 @@ meta:
   description: "Cisco Catalyst 2960X-24TD-L"
 
 canvas:
-  columns: 32
+  columns: 34
   rows: 2
 
 views:
@@ -19,18 +19,28 @@ views:
                 prefix: "gigabitethernet0-"
                 start: 1
                 count: 12
-                pattern: odd
+                pattern: top-odd
             - sequence:
                 kind: interface
                 prefix: "gigabitethernet0-"
                 start: 13
                 count: 12
-                pattern: odd
-      # Uplinks: 2 x 10GE SFP+ — row 1 blank, row 2 ports
+                pattern: top-odd
+      # 2 x GigSFP uplinks (GigabitEthernet1/0/25-26) — side-by-side in bottom row
       - spacer: 1
-      - elements:
-          - kind: blank
-            key: "y"
-          - kind: interface
-            key: "tengigabitethernet0-1"
+      - sequence:
+          kind: interface
+          prefix: "gigabitethernet0-"
+          start: 25
+          count: 2
+          pattern: all
+          row: 2
+      # 2 x 10GE SFP+ uplinks (TenGigabitEthernet1/0/1-2) — side-by-side in bottom row
       - spacer: 1
+      - sequence:
+          kind: interface
+          prefix: "tengigabitethernet0-"
+          start: 1
+          count: 2
+          pattern: all
+          row: 2

--- a/examples/yaml/Cisco/C2960X-24TD-L.yaml
+++ b/examples/yaml/Cisco/C2960X-24TD-L.yaml
@@ -1,0 +1,36 @@
+version: 1
+
+meta:
+  description: "Cisco Catalyst 2960X-24TD-L"
+
+canvas:
+  columns: 32
+  rows: 2
+
+views:
+  front:
+    rows:
+      - blank: 14
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 1
+                count: 12
+                pattern: odd
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 13
+                count: 12
+                pattern: odd
+      # Uplinks: 2 x 10GE SFP+ — row 1 blank, row 2 ports
+      - spacer: 1
+      - elements:
+          - kind: blank
+            key: "y"
+          - kind: interface
+            key: "tengigabitethernet0-1"
+      - spacer: 1

--- a/examples/yaml/Cisco/C8300-2N2S-4T2X.yaml
+++ b/examples/yaml/Cisco/C8300-2N2S-4T2X.yaml
@@ -1,0 +1,38 @@
+version: 1
+
+meta:
+  description: "Cisco C8300-2N2S-4T2X"
+
+canvas:
+  columns: 6
+  rows: 2
+
+views:
+  front:
+    rows:
+      - elements:
+          - kind: blank
+            key: "x1"
+          - kind: console-port
+            key: "con-0"
+          - kind: spacer
+            key: "s1"
+          - kind: interface
+            key: "gigabitethernet0-0"
+          - kind: interface
+            key: "gigabitethernet0-2"
+          - kind: interface
+            key: "tengigabitethernet0-4"
+      - elements:
+          - kind: blank
+            key: "x2"
+          - kind: blank
+            key: "y"
+          - kind: spacer
+            key: "s1"
+          - kind: interface
+            key: "gigabitethernet0-1"
+          - kind: interface
+            key: "gigabitethernet0-3"
+          - kind: interface
+            key: "tengigabitethernet0-5"

--- a/examples/yaml/Cisco/C9300-24T.yaml
+++ b/examples/yaml/Cisco/C9300-24T.yaml
@@ -19,14 +19,14 @@ views:
                 prefix: "gigabitethernet0-"
                 start: 1
                 count: 12
-                pattern: odd
+                pattern: top-odd
             - sequence:
                 kind: interface
                 prefix: "gigabitethernet0-"
                 start: 13
                 count: 12
-                pattern: odd
-      - spacer: 4  # trailing z padding
+                pattern: top-odd
+      - spacer: 4
 
 variants:
   C9300-NM-8X:
@@ -41,16 +41,16 @@ variants:
                 prefix: "gigabitethernet0-"
                 start: 1
                 count: 12
-                pattern: odd
+                pattern: top-odd
             - sequence:
                 kind: interface
                 prefix: "gigabitethernet0-"
                 start: 13
                 count: 12
-                pattern: odd
+                pattern: top-odd
             - sequence:
                 kind: interface
                 prefix: "tengigabitethernet1-"
                 start: 1
                 count: 8
-                pattern: odd
+                pattern: top-odd

--- a/examples/yaml/Cisco/C9300-24T.yaml
+++ b/examples/yaml/Cisco/C9300-24T.yaml
@@ -1,0 +1,56 @@
+version: 1
+
+meta:
+  description: "Cisco Catalyst 9300-24T"
+
+canvas:
+  columns: 32
+  rows: 2
+
+views:
+  front:
+    rows:
+      - blank: 14
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 1
+                count: 12
+                pattern: odd
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 13
+                count: 12
+                pattern: odd
+      - spacer: 4  # trailing z padding
+
+variants:
+  C9300-NM-8X:
+    match: module
+    rows:
+      - blank: 14
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 1
+                count: 12
+                pattern: odd
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 13
+                count: 12
+                pattern: odd
+            - sequence:
+                kind: interface
+                prefix: "tengigabitethernet1-"
+                start: 1
+                count: 8
+                pattern: odd

--- a/examples/yaml/Cisco/FPR1120-NGFW-K9.yaml
+++ b/examples/yaml/Cisco/FPR1120-NGFW-K9.yaml
@@ -1,0 +1,28 @@
+version: 1
+
+meta:
+  description: "Cisco Firepower FPR1120-NGFW-K9"
+  # Ports are named "ETH 1", "ETH 2" and so on
+  background: "#d9d9d9"
+
+canvas:
+  columns: 22
+  rows: 2
+
+views:
+  front:
+    rows:
+      - blank: 13
+      - sequence:
+          kind: interface
+          prefix: "ethernet-"
+          start: 1
+          count: 8
+          pattern: odd
+      - spacer: 3
+      - sequence:
+          kind: interface
+          prefix: "ethernet-"
+          start: 9
+          count: 4
+          pattern: odd

--- a/examples/yaml/Cisco/FPR1120-NGFW-K9.yaml
+++ b/examples/yaml/Cisco/FPR1120-NGFW-K9.yaml
@@ -2,27 +2,28 @@ version: 1
 
 meta:
   description: "Cisco Firepower FPR1120-NGFW-K9"
-  # Ports are named "ETH 1", "ETH 2" and so on
   background: "#d9d9d9"
 
 canvas:
-  columns: 22
+  columns: 14
   rows: 2
 
 views:
   front:
     rows:
-      - blank: 13
+      - blank: 5
+      # 8 x copper data ports (Ethernet1/1-8), staggered odd/even
       - sequence:
           kind: interface
           prefix: "ethernet-"
           start: 1
           count: 8
-          pattern: odd
-      - spacer: 3
+          pattern: top-odd
+      - spacer: 1
+      # 4 x SFP data ports (Ethernet1/9-12), staggered odd/even
       - sequence:
           kind: interface
           prefix: "ethernet-"
           start: 9
           count: 4
-          pattern: odd
+          pattern: top-odd

--- a/examples/yaml/Generic/24-ports-UTP-Patchpanel.yaml
+++ b/examples/yaml/Generic/24-ports-UTP-Patchpanel.yaml
@@ -1,0 +1,44 @@
+version: 1
+
+meta:
+  description: "Generic 24-port UTP Patch Panel"
+  # Ports named "Port 1", "Port 2" ... front and rear
+
+canvas:
+  columns: 28  # 24 ports + 3 spacers
+  rows: 1
+  cell_size: 0  # patch-panel: auto sizing
+
+views:
+  front:
+    rows:
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 1
+                count: 6
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 7
+                count: 6
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 13
+                count: 6
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 19
+                count: 6
+                pattern: all
+
+  rear:
+    copy_from: front

--- a/examples/yaml/Generic/24xLC-Patchpanel.yaml
+++ b/examples/yaml/Generic/24xLC-Patchpanel.yaml
@@ -1,0 +1,29 @@
+version: 1
+
+meta:
+  description: "Generic 24xLC Fiber Patch Panel"
+  # Front ports named "LC 1" ... "LC 24"; rear ports named "Rear Port 1" ... "Rear Port 24"
+
+canvas:
+  columns: 24
+  rows: 1
+  cell_size: 0  # patch-panel: auto sizing
+
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "lc-"
+          start: 1
+          count: 24
+          pattern: all
+
+  rear:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "rear-port-"
+          start: 1
+          count: 24
+          pattern: all

--- a/examples/yaml/Generic/48-ports-UTP-Patchpanel.yaml
+++ b/examples/yaml/Generic/48-ports-UTP-Patchpanel.yaml
@@ -1,0 +1,71 @@
+version: 1
+
+meta:
+  description: "Generic 48-port UTP Patch Panel"
+  # Ports named "Port 1" ... "Port 48" front and rear
+
+canvas:
+  columns: 31  # 48 ports + 6 spacers, across 2 rows
+  rows: 2
+  cell_size: 0  # patch-panel: auto sizing
+
+views:
+  front:
+    rows:
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 1
+                count: 6
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 7
+                count: 6
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 13
+                count: 6
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 19
+                count: 6
+                pattern: all
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 25
+                count: 6
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 31
+                count: 6
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 37
+                count: 6
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 43
+                count: 6
+                pattern: all
+
+  rear:
+    copy_from: front

--- a/examples/yaml/Generic/LC-48-port-Fiber-Patchpanel.yaml
+++ b/examples/yaml/Generic/LC-48-port-Fiber-Patchpanel.yaml
@@ -1,0 +1,29 @@
+version: 1
+
+meta:
+  description: "Generic LC 48-port Fiber Patch Panel"
+  # Front and rear ports named "Port 1" ... "Port 48"
+
+canvas:
+  columns: 24
+  rows: 2
+  cell_size: 0  # patch-panel: auto sizing
+
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "port-"
+          start: 1
+          count: 24
+          pattern: all
+      - sequence:
+          kind: port
+          prefix: "port-"
+          start: 25
+          count: 24
+          pattern: all
+
+  rear:
+    copy_from: front

--- a/examples/yaml/Generic/SC-24-port_Fiber_Patch_Panel.yaml
+++ b/examples/yaml/Generic/SC-24-port_Fiber_Patch_Panel.yaml
@@ -1,0 +1,23 @@
+version: 1
+
+meta:
+  description: "Generic SC 24-port Fiber Patch Panel"
+  # Front and rear ports named "1", "2" ... (stylenames become p1, p2, ...)
+
+canvas:
+  columns: 24
+  rows: 1
+  cell_size: 0  # patch-panel: auto sizing
+
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 24
+          pattern: all
+
+  rear:
+    copy_from: front

--- a/examples/yaml/Ubiquiti/USW-Enterprise-24-PoE.yaml
+++ b/examples/yaml/Ubiquiti/USW-Enterprise-24-PoE.yaml
@@ -1,0 +1,49 @@
+version: 1
+
+meta:
+  description: "Ubiquiti UniFi Switch Enterprise 24 PoE"
+
+canvas:
+  columns: 32
+  rows: 2
+
+views:
+  front:
+    rows:
+      - blank: 32   # top decorative row (empty)
+      - elements:
+          # Two blank cells on the left
+          - kind: blank
+            key: "y1"
+          - kind: blank
+            key: "y2"
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 1
+                count: 8
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 9
+                count: 8
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "port-"
+                start: 17
+                count: 8
+                pattern: all
+      - spacer: 1
+      - elements:
+          - kind: interface
+            key: "sfp--25"
+          - kind: interface
+            key: "sfp--26"
+      - elements:
+          - kind: blank
+            key: "z"

--- a/netbox_device_view/api/serializers.py
+++ b/netbox_device_view/api/serializers.py
@@ -10,6 +10,7 @@ class DeviceViewSerializer(NetBoxModelSerializer):
             "display",
             "device_type",
             "grid_template_area",
+            "yaml_layout",
             "tags",
             "custom_fields",
             "created",

--- a/netbox_device_view/forms.py
+++ b/netbox_device_view/forms.py
@@ -8,7 +8,7 @@ from utilities.forms.fields import CSVModelChoiceField
 class DeviceViewForm(NetBoxModelForm):
     class Meta:
         model = DeviceView
-        fields = ("device_type", "grid_template_area")
+        fields = ("device_type", "grid_template_area", "yaml_layout")
 
 
 class DeviceViewImportForm(NetBoxModelImportForm):
@@ -20,4 +20,4 @@ class DeviceViewImportForm(NetBoxModelImportForm):
 
     class Meta:
         model = DeviceView
-        fields = ("device_type", "grid_template_area")
+        fields = ("device_type", "grid_template_area", "yaml_layout")

--- a/netbox_device_view/layout/__init__.py
+++ b/netbox_device_view/layout/__init__.py
@@ -1,0 +1,83 @@
+"""
+netbox_device_view.layout — YAML layout schema, parser, and renderers.
+
+Public API
+----------
+  from netbox_device_view.layout import parse_yaml, render_css, validate_yaml
+
+  # Parse a YAML layout string → NormalizedLayout
+  layout = parse_yaml(yaml_text)
+
+  # Render a NormalizedLayout → CSS string
+  css = render_css(layout)
+
+  # Validate YAML and return a list of error strings (empty = valid)
+  errors = validate_yaml(yaml_text)
+
+  # Get CSS from a DeviceView record (handles both YAML and legacy)
+  css = get_css_for_device_view(device_view_obj)
+"""
+
+from .legacy import wrap_legacy_css
+from .model import (
+    CanvasConfig,
+    ElementKind,
+    Face,
+    LayoutView,
+    NormalizedLayout,
+    PlacedElement,
+)
+from .parser import LayoutParseError, parse, validate
+from .renderers.css_grid import render
+
+__all__ = [
+    # Model
+    "NormalizedLayout",
+    "LayoutView",
+    "PlacedElement",
+    "CanvasConfig",
+    "ElementKind",
+    "Face",
+    # Parser
+    "parse",
+    "validate",
+    "LayoutParseError",
+    # Legacy adapter
+    "wrap_legacy_css",
+    # Renderer
+    "render",
+    # Convenience aliases
+    "parse_yaml",
+    "render_css",
+    "validate_yaml",
+    "get_css_for_device_view",
+]
+
+# Convenience aliases
+parse_yaml = parse
+render_css = render
+validate_yaml = validate
+
+
+def get_css_for_device_view(device_view) -> str:
+    """
+    Return the CSS string to inject for a DeviceView record.
+
+    Prefers YAML layout when present; falls back to legacy CSS.
+
+    Parameters
+    ----------
+    device_view : DeviceView
+        A DeviceView model instance with ``yaml_layout`` and
+        ``grid_template_area`` fields.
+
+    Returns
+    -------
+    str
+        Raw CSS text ready to inject into a <style> block.
+    """
+    if device_view.has_yaml_layout:
+        layout = parse(device_view.yaml_layout)
+        return render(layout)
+    # Legacy path — return as-is
+    return device_view.grid_template_area

--- a/netbox_device_view/layout/legacy.py
+++ b/netbox_device_view/layout/legacy.py
@@ -1,0 +1,45 @@
+"""
+Legacy CSS adapter.
+
+Wraps the existing ``grid_template_area`` CSS string in a NormalizedLayout so
+that downstream code can treat both YAML and legacy sources uniformly.
+
+The adapter does NOT attempt to parse or re-interpret the CSS — that would be
+fragile and unnecessary.  Instead it stores the raw CSS string and marks the
+layout as ``source="legacy_css"``.
+
+Renderers that need raw CSS (i.e., the CSS Grid renderer in legacy mode) can
+check ``layout.source`` and short-circuit to the raw string rather than
+reconstructing it from elements.
+
+This means ``NormalizedLayout.views`` will be empty for legacy layouts, and
+``layout.raw_css`` holds the authoritative rendering string.  Future
+renderers (SVG) would need to parse the CSS or prompt users to migrate to
+YAML — but that is a problem for a future phase.
+"""
+
+from __future__ import annotations
+
+from .model import NormalizedLayout
+
+
+def wrap_legacy_css(css_text: str, description: str = "") -> NormalizedLayout:
+    """
+    Wrap a raw legacy CSS string in a NormalizedLayout.
+
+    The resulting layout's ``source`` is ``"legacy_css"`` and its ``views``
+    dict is empty.  The CSS text is stored on ``layout.raw_css``.
+
+    Usage
+    -----
+    ::
+
+        layout = wrap_legacy_css(device_view.grid_template_area)
+        if layout.source == "legacy_css":
+            css = layout.raw_css   # use as-is
+        else:
+            css = css_grid.render(layout)
+    """
+    layout = NormalizedLayout(description=description, source="legacy_css")
+    layout.raw_css = css_text  # type: ignore[attr-defined]  # dynamic attribute
+    return layout

--- a/netbox_device_view/layout/model.py
+++ b/netbox_device_view/layout/model.py
@@ -74,7 +74,11 @@ class PlacedElement:
     @property
     def is_port(self) -> bool:
         """True for elements that correspond to a real NetBox port/interface."""
-        return self.kind not in (ElementKind.SPACER, ElementKind.BLANK, ElementKind.LABEL)
+        return self.kind not in (
+            ElementKind.SPACER,
+            ElementKind.BLANK,
+            ElementKind.LABEL,
+        )
 
 
 @dataclass
@@ -109,7 +113,9 @@ class LayoutView:
     # variant_name → list[PlacedElement] overrides/additions
     variants: dict[str, list[PlacedElement]] = field(default_factory=dict)
 
-    def elements_for_variant(self, variant_name: Optional[str] = None) -> list[PlacedElement]:
+    def elements_for_variant(
+        self, variant_name: Optional[str] = None
+    ) -> list[PlacedElement]:
         """
         Return the full element list for a given module variant.
 

--- a/netbox_device_view/layout/model.py
+++ b/netbox_device_view/layout/model.py
@@ -1,0 +1,156 @@
+"""
+Normalized internal layout model.
+
+This module defines the canonical in-memory representation that both the
+YAML parser and the legacy CSS adapter produce. All renderers (CSS Grid,
+and future SVG) consume this model exclusively, so the schema can stay
+stable while renderers are added or changed independently.
+
+Data classes are intentionally plain Python (no Django dependency) so they
+can be used in tests and tooling without a running NetBox instance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class ElementKind(str, Enum):
+    """The logical type of a layout element."""
+
+    PORT = "port"
+    INTERFACE = "interface"
+    CONSOLE_PORT = "console-port"
+    POWER_PORT = "power-port"
+    MODULE_SLOT = "module-slot"
+    SPACER = "spacer"
+    LABEL = "label"
+    BLANK = "blank"  # decorative filler (x / y in legacy CSS)
+
+
+class Face(str, Enum):
+    """Which physical face of the device this element belongs to."""
+
+    FRONT = "front"
+    REAR = "rear"
+    BOTH = "both"  # applies to both (default for 1U switches)
+
+
+@dataclass
+class PlacedElement:
+    """
+    A single element placed on the device layout grid.
+
+    Coordinates use 1-based row/col to match CSS grid conventions.
+    ``span`` defaults to (1, 1) — a single cell.
+
+    ``key`` is the CSS grid-area name / stylename that links this element
+    to a real NetBox port or interface object.  For spacers and blanks the
+    key is just a unique placeholder name (e.g. ``s0``, ``x0``).
+    """
+
+    kind: ElementKind
+    key: str  # CSS grid-area name / stylename
+    face: Face = Face.BOTH
+
+    # Grid placement (1-based, matching CSS grid-row / grid-column)
+    row: int = 1
+    col: int = 1
+    row_span: int = 1
+    col_span: int = 1
+
+    # Optional display label (for label elements and future SVG tooltips)
+    label: Optional[str] = None
+
+    # Extra CSS class names to attach (for styling hooks)
+    css_classes: list[str] = field(default_factory=list)
+
+    # Variant context: if set, this element only appears when the named
+    # module is installed (mirrors .deviceview.module<Name>.area in CSS)
+    variant: Optional[str] = None
+
+    @property
+    def is_port(self) -> bool:
+        """True for elements that correspond to a real NetBox port/interface."""
+        return self.kind not in (ElementKind.SPACER, ElementKind.BLANK, ElementKind.LABEL)
+
+
+@dataclass
+class CanvasConfig:
+    """
+    Physical canvas dimensions.
+
+    ``columns`` and ``rows`` describe the grid.  ``cell_size`` (px) is used
+    by the SVG renderer; the CSS Grid renderer ignores it (CSS uses 20 px
+    cells defined in device_view.css).
+    """
+
+    columns: int = 32
+    rows: int = 2
+    cell_size: int = 20  # pixels — for SVG renderer
+    background: Optional[str] = None  # CSS color string
+
+
+@dataclass
+class LayoutView:
+    """
+    A single rendered view (front or rear).
+
+    Contains an ordered list of PlacedElement objects and a canvas config.
+    Elements are ordered by (row, col) but renderers may reorder them.
+    """
+
+    face: Face
+    canvas: CanvasConfig
+    elements: list[PlacedElement] = field(default_factory=list)
+
+    # variant_name → list[PlacedElement] overrides/additions
+    variants: dict[str, list[PlacedElement]] = field(default_factory=dict)
+
+    def elements_for_variant(self, variant_name: Optional[str] = None) -> list[PlacedElement]:
+        """
+        Return the full element list for a given module variant.
+
+        Base elements without a variant always apply.  If ``variant_name``
+        is given, elements tagged with that variant are also included,
+        replacing any base element with the same key.
+        """
+        base = {el.key: el for el in self.elements if el.variant is None}
+        if variant_name and variant_name in self.variants:
+            for el in self.variants[variant_name]:
+                base[el.key] = el
+        return list(base.values())
+
+
+@dataclass
+class NormalizedLayout:
+    """
+    The top-level normalized layout for a device type.
+
+    A device type may have a ``front`` view, a ``rear`` view, or both.
+    Patch panels typically expose both; switches usually only ``front``.
+
+    This is the object that renderers receive.
+    """
+
+    # Human-readable description (from YAML meta or CSS comment)
+    description: str = ""
+
+    # Source format tag — informational only
+    source: str = "yaml"  # "yaml" | "legacy_css"
+
+    views: dict[str, LayoutView] = field(default_factory=dict)
+
+    @property
+    def front(self) -> Optional[LayoutView]:
+        return self.views.get(Face.FRONT.value) or self.views.get("front")
+
+    @property
+    def rear(self) -> Optional[LayoutView]:
+        return self.views.get(Face.REAR.value) or self.views.get("rear")
+
+    def has_separate_faces(self) -> bool:
+        """True when the device exposes distinct front and rear views."""
+        return "front" in self.views and "rear" in self.views

--- a/netbox_device_view/layout/parser.py
+++ b/netbox_device_view/layout/parser.py
@@ -1,0 +1,633 @@
+"""
+YAML layout parser and compiler.
+
+Parses the YAML-based layout schema and compiles it into a NormalizedLayout.
+
+Schema overview
+---------------
+version: 1
+meta:
+  description: "Human-readable name"
+  background: "#d9d9d9"    # optional default background for all views
+
+canvas:
+  columns: 32              # total grid columns
+  rows: 2                  # total grid rows
+  cell_size: 20            # px per cell (for future SVG renderer)
+
+views:
+  front:                   # or "rear", or both
+    background: "#000"     # optional per-view background override
+    rows:                  # ordered list of row definitions
+      - elements: [...]    # inline element list
+      - sequence:          # expand a port sequence
+          kind: port
+          prefix: "gigabitethernet0-"
+          start: 1
+          count: 12
+          pattern: odd     # "odd" | "even" | "all" (default)
+      - spacer: 1          # shorthand: insert N spacer columns
+      - blank: 4           # shorthand: insert N blank (x) columns
+
+variants:
+  C9300-NM-8X:             # module model name
+    match: module           # "module" (matched by installed module model)
+    rows:
+      - elements: [...]
+
+# Alternatively, views can use the flat "elements" list with explicit at:/span:
+views:
+  front:
+    elements:
+      - kind: port
+        key: "gigabitethernet0-1"
+        at: {row: 1, col: 15}
+      - kind: spacer
+        at: {row: 1, col: 14}
+        span: {rows: 2, cols: 1}
+      - kind: blank
+        at: {row: 1, col: 1}
+        span: {rows: 2, cols: 14}
+
+Sequence helper
+---------------
+A sequence expands into multiple port elements.  The ``pattern`` key controls
+which ports go in which row when the canvas has 2 rows:
+
+  pattern: odd      → ports 1, 3, 5, … in row 1; 2, 4, 6, … in row 2
+  pattern: even     → ports 2, 4, 6, … in row 1; 1, 3, 5, … in row 2
+  pattern: all      → all ports in a single row (patch panel style)
+
+Group helper
+------------
+A group is a list of sequences/elements separated by spacers:
+
+  - group:
+      spacer: 1
+      sections:
+        - sequence: ...
+        - sequence: ...
+
+copy_from / extend_view
+-----------------------
+A view can copy another view's row definitions and add overrides:
+
+  views:
+    rear:
+      copy_from: front
+      # additional elements appended / overriding by key
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+import yaml
+
+from .model import (
+    CanvasConfig,
+    ElementKind,
+    Face,
+    LayoutView,
+    NormalizedLayout,
+    PlacedElement,
+)
+
+# ── Schema version supported by this parser ──────────────────────────────────
+SUPPORTED_VERSION = 1
+
+# ── Mapping from YAML kind strings to ElementKind enum ───────────────────────
+_KIND_MAP: dict[str, ElementKind] = {
+    "port": ElementKind.PORT,
+    "interface": ElementKind.INTERFACE,
+    "console-port": ElementKind.CONSOLE_PORT,
+    "console_port": ElementKind.CONSOLE_PORT,
+    "power-port": ElementKind.POWER_PORT,
+    "power_port": ElementKind.POWER_PORT,
+    "module-slot": ElementKind.MODULE_SLOT,
+    "module_slot": ElementKind.MODULE_SLOT,
+    "spacer": ElementKind.SPACER,
+    "blank": ElementKind.BLANK,
+    "label": ElementKind.LABEL,
+}
+
+_PORT_KINDS = {
+    ElementKind.PORT,
+    ElementKind.INTERFACE,
+    ElementKind.CONSOLE_PORT,
+    ElementKind.POWER_PORT,
+    ElementKind.MODULE_SLOT,
+}
+
+
+class LayoutParseError(ValueError):
+    """Raised when the YAML layout schema is invalid."""
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def parse(yaml_text: str) -> NormalizedLayout:
+    """
+    Parse a YAML layout string and return a NormalizedLayout.
+
+    Raises LayoutParseError on schema violations.
+    """
+    try:
+        data = yaml.safe_load(yaml_text)
+    except yaml.YAMLError as exc:
+        raise LayoutParseError(f"Invalid YAML: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise LayoutParseError("Layout must be a YAML mapping at the top level.")
+
+    version = data.get("version", 1)
+    if int(version) != SUPPORTED_VERSION:
+        raise LayoutParseError(
+            f"Unsupported layout version {version!r}. "
+            f"This parser supports version {SUPPORTED_VERSION}."
+        )
+
+    meta = data.get("meta", {}) or {}
+    description = meta.get("description", "")
+    global_bg = meta.get("background", None)
+
+    canvas_cfg = _parse_canvas(data.get("canvas", {}), global_bg)
+
+    # Collect raw view definitions
+    raw_views: dict[str, Any] = data.get("views", {}) or {}
+    raw_variants: dict[str, Any] = data.get("variants", {}) or {}
+
+    layout = NormalizedLayout(description=description, source="yaml")
+
+    # First pass: compile all views (copy_from resolution happens here)
+    compiled_views: dict[str, LayoutView] = {}
+    for view_name, view_data in raw_views.items():
+        face = _parse_face(view_name)
+        view_canvas = _parse_canvas(view_data.get("canvas", {}), global_bg, canvas_cfg)
+        compiled_views[view_name] = _compile_view(
+            view_name, view_data, face, view_canvas, raw_views, canvas_cfg, global_bg
+        )
+
+    # Second pass: compile variants into each affected view
+    for variant_name, variant_data in raw_variants.items():
+        variant_view_name = variant_data.get("view", "front")
+        if variant_view_name not in compiled_views:
+            # Create an implicit front view if needed
+            compiled_views[variant_view_name] = LayoutView(
+                face=Face.FRONT,
+                canvas=canvas_cfg,
+            )
+        view = compiled_views[variant_view_name]
+        variant_elements = _compile_rows(
+            variant_data.get("rows", []),
+            variant_data.get("elements", []),
+            view.canvas,
+            variant_name=variant_name,
+        )
+        view.variants[variant_name] = variant_elements
+
+    layout.views = compiled_views
+    return layout
+
+
+def validate(yaml_text: str) -> list[str]:
+    """
+    Validate a YAML layout and return a list of error messages.
+    Returns an empty list if the layout is valid.
+    """
+    errors: list[str] = []
+    try:
+        parse(yaml_text)
+    except LayoutParseError as exc:
+        errors.append(str(exc))
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"Unexpected error: {exc}")
+    return errors
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+
+def _parse_face(name: str) -> Face:
+    mapping = {"front": Face.FRONT, "rear": Face.REAR, "both": Face.BOTH}
+    return mapping.get(name.lower(), Face.FRONT)
+
+
+def _parse_canvas(
+    raw: Any,
+    global_bg: Optional[str] = None,
+    parent: Optional[CanvasConfig] = None,
+) -> CanvasConfig:
+    """Merge canvas config from raw dict, inheriting from parent if given."""
+    if not isinstance(raw, dict):
+        raw = {}
+    p = parent or CanvasConfig()
+    return CanvasConfig(
+        columns=int(raw.get("columns", p.columns)),
+        rows=int(raw.get("rows", p.rows)),
+        cell_size=int(raw.get("cell_size", p.cell_size)),
+        background=raw.get("background", global_bg or p.background),
+    )
+
+
+def _compile_view(
+    view_name: str,
+    view_data: Any,
+    face: Face,
+    canvas: CanvasConfig,
+    raw_views: dict[str, Any],
+    global_canvas: CanvasConfig,
+    global_bg: Optional[str],
+) -> LayoutView:
+    """Compile a single view, handling copy_from."""
+    if not isinstance(view_data, dict):
+        view_data = {}
+
+    # Handle copy_from
+    base_elements: list[PlacedElement] = []
+    copy_from = view_data.get("copy_from")
+    if copy_from:
+        if copy_from not in raw_views:
+            raise LayoutParseError(
+                f"View '{view_name}' references copy_from='{copy_from}' "
+                f"which does not exist."
+            )
+        src = raw_views[copy_from]
+        src_canvas = _parse_canvas(src.get("canvas", {}), global_bg, global_canvas)
+        base_elements = _compile_rows(
+            src.get("rows", []),
+            src.get("elements", []),
+            src_canvas,
+        )
+
+    elements = _compile_rows(
+        view_data.get("rows", []),
+        view_data.get("elements", []),
+        canvas,
+    )
+
+    # Merge: base_elements first, then this view's elements override by key
+    if base_elements:
+        merged: dict[str, PlacedElement] = {el.key: el for el in base_elements}
+        for el in elements:
+            merged[el.key] = el
+        elements = list(merged.values())
+
+    return LayoutView(face=face, canvas=canvas, elements=elements)
+
+
+def _compile_rows(
+    rows: list[Any],
+    flat_elements: list[Any],
+    canvas: CanvasConfig,
+    variant_name: Optional[str] = None,
+) -> list[PlacedElement]:
+    """
+    Compile either a rows-based or flat elements-based definition into
+    a list of PlacedElement objects.
+    """
+    if flat_elements:
+        return _compile_flat_elements(flat_elements, canvas, variant_name)
+    if rows:
+        return _compile_rows_definition(rows, canvas, variant_name)
+    return []
+
+
+def _compile_flat_elements(
+    elements: list[Any],
+    canvas: CanvasConfig,
+    variant_name: Optional[str],
+) -> list[PlacedElement]:
+    """Compile an explicit list of element dicts with at:/span: coordinates."""
+    result: list[PlacedElement] = []
+    for i, raw in enumerate(elements):
+        if not isinstance(raw, dict):
+            raise LayoutParseError(f"Element #{i} must be a mapping, got {type(raw).__name__}.")
+        result.extend(_expand_element(raw, canvas, variant_name))
+    return result
+
+
+def _compile_rows_definition(
+    rows: list[Any],
+    canvas: CanvasConfig,
+    variant_name: Optional[str],
+) -> list[PlacedElement]:
+    """
+    Compile a rows-style definition.
+
+    Each entry in ``rows`` can be:
+      - {elements: [...]}         explicit list for this row
+      - {sequence: {...}}         expanded port sequence
+      - {spacer: N}               insert N spacer columns
+      - {blank: N}                insert N blank columns
+      - {group: {spacer: N, sections: [...]}}  grouped sequences
+
+    Row number is determined by the ``pattern`` of each sequence:
+      - "all"  → fills a single row (auto-incremented)
+      - "odd"  → odd-numbered ports go in row 1
+      - "even" → even-numbered ports go in row 2 (row 1 gets the evens)
+    """
+    result: list[PlacedElement] = []
+
+    # We build a column cursor per row. row_cursors[1], row_cursors[2], …
+    row_cursors: dict[int, int] = {r: 1 for r in range(1, canvas.rows + 1)}
+    current_single_row = 1  # for "all"-pattern sequences
+
+    for entry in rows:
+        if not isinstance(entry, dict):
+            raise LayoutParseError(f"Row entry must be a mapping, got {type(entry).__name__}.")
+
+        if "elements" in entry:
+            elements, row_cursors = _compile_explicit_row(
+                entry["elements"], row_cursors, current_single_row, canvas, variant_name
+            )
+            result.extend(elements)
+            current_single_row = min(current_single_row + 1, canvas.rows)
+
+        elif "sequence" in entry:
+            elements, row_cursors = _expand_sequence(
+                entry["sequence"], row_cursors, canvas, variant_name
+            )
+            result.extend(elements)
+
+        elif "group" in entry:
+            elements, row_cursors = _expand_group(
+                entry["group"], row_cursors, canvas, variant_name
+            )
+            result.extend(elements)
+
+        elif "spacer" in entry:
+            n = int(entry["spacer"])
+            spacer_elements, row_cursors = _insert_filler(
+                ElementKind.SPACER, n, row_cursors, canvas, variant_name, prefix="s"
+            )
+            result.extend(spacer_elements)
+
+        elif "blank" in entry:
+            n = int(entry["blank"])
+            blank_elements, row_cursors = _insert_filler(
+                ElementKind.BLANK, n, row_cursors, canvas, variant_name, prefix="x"
+            )
+            result.extend(blank_elements)
+
+        else:
+            raise LayoutParseError(
+                f"Unknown row entry keys: {list(entry.keys())}. "
+                "Expected one of: elements, sequence, group, spacer, blank."
+            )
+
+    return result
+
+
+def _compile_explicit_row(
+    elements: list[Any],
+    row_cursors: dict[int, int],
+    current_row: int,
+    canvas: CanvasConfig,
+    variant_name: Optional[str],
+) -> tuple[list[PlacedElement], dict[int, int]]:
+    """Place an explicit list of elements into ``current_row``."""
+    result: list[PlacedElement] = []
+    col = row_cursors.get(current_row, 1)
+    for raw in elements:
+        if isinstance(raw, str):
+            # shorthand: just a key name, infer kind
+            kind = ElementKind.SPACER if raw.startswith("s") and raw[1:].isdigit() else ElementKind.BLANK if raw in ("x", "y") else ElementKind.PORT
+            result.append(PlacedElement(
+                kind=kind, key=raw, row=current_row, col=col, variant=variant_name
+            ))
+            col += 1
+        elif isinstance(raw, dict):
+            expanded = _expand_element(raw, canvas, variant_name, default_row=current_row, default_col=col)
+            result.extend(expanded)
+            col += sum(el.col_span for el in expanded)
+        else:
+            raise LayoutParseError(f"Element must be a string key or mapping, got {type(raw).__name__}.")
+    row_cursors[current_row] = col
+    return result, row_cursors
+
+
+def _expand_sequence(
+    seq: Any,
+    row_cursors: dict[int, int],
+    canvas: CanvasConfig,
+    variant_name: Optional[str],
+) -> tuple[list[PlacedElement], dict[int, int]]:
+    """
+    Expand a sequence definition into PlacedElement objects.
+
+    sequence:
+      kind: port           # default: port
+      prefix: "gigabitethernet0-"
+      start: 1             # first port number (default: 1)
+      count: 24            # how many ports
+      pattern: odd         # "odd" | "even" | "all"
+      step: 1              # increment between ports (default: 1)
+    """
+    if not isinstance(seq, dict):
+        raise LayoutParseError("'sequence' must be a mapping.")
+
+    kind_str = seq.get("kind", "port")
+    kind = _KIND_MAP.get(kind_str)
+    if kind is None:
+        raise LayoutParseError(f"Unknown element kind: {kind_str!r}.")
+
+    prefix = seq.get("prefix", "")
+    start = int(seq.get("start", 1))
+    count = int(seq.get("count", 1))
+    step = int(seq.get("step", 1))
+    pattern = seq.get("pattern", "odd")
+
+    # Generate port numbers
+    port_numbers = [start + i * step for i in range(count)]
+
+    result: list[PlacedElement] = []
+    row_cursors = dict(row_cursors)  # copy
+
+    if pattern == "all":
+        # All ports in a single row (patch-panel style)
+        row = _single_active_row(row_cursors, canvas)
+        col = row_cursors.get(row, 1)
+        for n in port_numbers:
+            key = f"{prefix}{n}"
+            result.append(PlacedElement(kind=kind, key=key, row=row, col=col, variant=variant_name))
+            col += 1
+        row_cursors[row] = col
+
+    elif pattern in ("odd", "even"):
+        # Two-row layout: odd ports in row 1, even ports in row 2
+        # (or swapped for "even" pattern — useful when even ports are physically on top)
+        row1, row2 = (1, 2) if canvas.rows >= 2 else (1, 1)
+        if pattern == "even":
+            row1, row2 = row2, row1
+
+        # Find the starting column (max of the two row cursors to keep alignment)
+        start_col = max(row_cursors.get(row1, 1), row_cursors.get(row2, 1))
+        col1 = col2 = start_col
+
+        for n in port_numbers:
+            key = f"{prefix}{n}"
+            if n % 2 == 1:  # odd
+                result.append(PlacedElement(kind=kind, key=key, row=row1, col=col1, variant=variant_name))
+                col1 += 1
+            else:  # even
+                result.append(PlacedElement(kind=kind, key=key, row=row2, col=col2, variant=variant_name))
+                col2 += 1
+
+        # Both cursors advance to the same column
+        final_col = max(col1, col2)
+        row_cursors[row1] = final_col
+        row_cursors[row2] = final_col
+
+    else:
+        raise LayoutParseError(f"Unknown sequence pattern: {pattern!r}. Use 'odd', 'even', or 'all'.")
+
+    return result, row_cursors
+
+
+def _expand_group(
+    group: Any,
+    row_cursors: dict[int, int],
+    canvas: CanvasConfig,
+    variant_name: Optional[str],
+) -> tuple[list[PlacedElement], dict[int, int]]:
+    """
+    Expand a group of sections separated by spacers.
+
+    group:
+      spacer: 1        # spacer width between sections
+      sections:
+        - sequence: ...
+        - sequence: ...
+    """
+    if not isinstance(group, dict):
+        raise LayoutParseError("'group' must be a mapping.")
+
+    spacer_width = int(group.get("spacer", 1))
+    sections = group.get("sections", [])
+    result: list[PlacedElement] = []
+
+    for i, section in enumerate(sections):
+        if i > 0:
+            # Insert spacer between sections
+            spacer_els, row_cursors = _insert_filler(
+                ElementKind.SPACER, spacer_width, row_cursors, canvas, variant_name, prefix="s"
+            )
+            result.extend(spacer_els)
+
+        if not isinstance(section, dict):
+            raise LayoutParseError("Group section must be a mapping.")
+
+        if "sequence" in section:
+            els, row_cursors = _expand_sequence(section["sequence"], row_cursors, canvas, variant_name)
+            result.extend(els)
+        elif "elements" in section:
+            row = _single_active_row(row_cursors, canvas)
+            els, row_cursors = _compile_explicit_row(section["elements"], row_cursors, row, canvas, variant_name)
+            result.extend(els)
+        elif "blank" in section:
+            n = int(section["blank"])
+            els, row_cursors = _insert_filler(ElementKind.BLANK, n, row_cursors, canvas, variant_name, prefix="x")
+            result.extend(els)
+        else:
+            raise LayoutParseError(f"Unknown group section keys: {list(section.keys())}.")
+
+    return result, row_cursors
+
+
+def _insert_filler(
+    kind: ElementKind,
+    count: int,
+    row_cursors: dict[int, int],
+    canvas: CanvasConfig,
+    variant_name: Optional[str],
+    prefix: str = "x",
+) -> tuple[list[PlacedElement], dict[int, int]]:
+    """Insert ``count`` filler elements spanning all active rows."""
+    result: list[PlacedElement] = []
+    row_cursors = dict(row_cursors)
+    start_col = max(row_cursors.get(r, 1) for r in range(1, canvas.rows + 1))
+
+    for i in range(count):
+        col = start_col + i
+        # Generate a unique key that won't clash with port names
+        key = f"{prefix}{col}"
+        if canvas.rows >= 2:
+            # One element spanning all rows
+            result.append(PlacedElement(
+                kind=kind,
+                key=key,
+                row=1,
+                col=col,
+                row_span=canvas.rows,
+                col_span=1,
+                variant=variant_name,
+            ))
+        else:
+            result.append(PlacedElement(
+                kind=kind, key=key, row=1, col=col, variant=variant_name
+            ))
+
+    # Advance all row cursors
+    new_col = start_col + count
+    for r in range(1, canvas.rows + 1):
+        row_cursors[r] = new_col
+
+    return result, row_cursors
+
+
+def _expand_element(
+    raw: dict[str, Any],
+    canvas: CanvasConfig,
+    variant_name: Optional[str],
+    default_row: int = 1,
+    default_col: int = 1,
+) -> list[PlacedElement]:
+    """Compile a single explicit element dict."""
+    kind_str = raw.get("kind", "port")
+    kind = _KIND_MAP.get(kind_str)
+    if kind is None:
+        raise LayoutParseError(f"Unknown element kind: {kind_str!r}.")
+
+    at = raw.get("at", {}) or {}
+    span = raw.get("span", {}) or {}
+
+    row = int(at.get("row", default_row))
+    col = int(at.get("col", default_col))
+    row_span = int(span.get("rows", 1))
+    col_span = int(span.get("cols", 1))
+
+    # key is required for port-like elements; optional for spacers/blanks
+    key = raw.get("key", "")
+    if not key:
+        if kind in _PORT_KINDS:
+            raise LayoutParseError(f"Element of kind {kind_str!r} must have a 'key'.")
+        # auto-generate for spacers/blanks
+        key = f"{'s' if kind == ElementKind.SPACER else 'x'}{col}"
+
+    label = raw.get("label")
+    css_classes = raw.get("css_classes", []) or []
+
+    face_str = raw.get("face", "both")
+    face_map = {"front": Face.FRONT, "rear": Face.REAR, "both": Face.BOTH}
+    face = face_map.get(face_str, Face.BOTH)
+
+    return [PlacedElement(
+        kind=kind,
+        key=key,
+        face=face,
+        row=row,
+        col=col,
+        row_span=row_span,
+        col_span=col_span,
+        label=label,
+        css_classes=list(css_classes),
+        variant=variant_name,
+    )]
+
+
+def _single_active_row(row_cursors: dict[int, int], canvas: CanvasConfig) -> int:
+    """Return the first row number (1) for single-row operations."""
+    return 1

--- a/netbox_device_view/layout/parser.py
+++ b/netbox_device_view/layout/parser.py
@@ -25,7 +25,7 @@ views:
           prefix: "gigabitethernet0-"
           start: 1
           count: 12
-          pattern: odd     # "odd" | "even" | "all" (default)
+          pattern: top-odd  # "top-odd" | "top-even" | "all" (default: top-odd)
       - spacer: 1          # shorthand: insert N spacer columns
       - blank: 4           # shorthand: insert N blank (x) columns
 
@@ -54,9 +54,10 @@ Sequence helper
 A sequence expands into multiple port elements.  The ``pattern`` key controls
 which ports go in which row when the canvas has 2 rows:
 
-  pattern: odd      → ports 1, 3, 5, … in row 1; 2, 4, 6, … in row 2
-  pattern: even     → ports 2, 4, 6, … in row 1; 1, 3, 5, … in row 2
+  pattern: top-odd  → ports 1, 3, 5, … in row 1; 2, 4, 6, … in row 2
+  pattern: top-even → ports 2, 4, 6, … in row 1; 1, 3, 5, … in row 2
   pattern: all      → all ports in a single row (patch panel style)
+                      optional ``row: 2`` places them in the bottom row instead of row 1
 
 Group helper
 ------------
@@ -80,7 +81,6 @@ A view can copy another view's row definitions and add overrides:
 
 from __future__ import annotations
 
-import re
 from typing import Any, Optional
 
 import yaml
@@ -304,7 +304,9 @@ def _compile_flat_elements(
     result: list[PlacedElement] = []
     for i, raw in enumerate(elements):
         if not isinstance(raw, dict):
-            raise LayoutParseError(f"Element #{i} must be a mapping, got {type(raw).__name__}.")
+            raise LayoutParseError(
+                f"Element #{i} must be a mapping, got {type(raw).__name__}."
+            )
         result.extend(_expand_element(raw, canvas, variant_name))
     return result
 
@@ -326,8 +328,8 @@ def _compile_rows_definition(
 
     Row number is determined by the ``pattern`` of each sequence:
       - "all"  → fills a single row (auto-incremented)
-      - "odd"  → odd-numbered ports go in row 1
-      - "even" → even-numbered ports go in row 2 (row 1 gets the evens)
+      - "top-odd"  → odd-numbered ports go in row 1
+      - "top-even" → even-numbered ports go in row 1 (row 2 gets the odds)
     """
     result: list[PlacedElement] = []
 
@@ -337,7 +339,9 @@ def _compile_rows_definition(
 
     for entry in rows:
         if not isinstance(entry, dict):
-            raise LayoutParseError(f"Row entry must be a mapping, got {type(entry).__name__}.")
+            raise LayoutParseError(
+                f"Row entry must be a mapping, got {type(entry).__name__}."
+            )
 
         if "elements" in entry:
             elements, row_cursors = _compile_explicit_row(
@@ -394,17 +398,27 @@ def _compile_explicit_row(
     for raw in elements:
         if isinstance(raw, str):
             # shorthand: just a key name, infer kind
-            kind = ElementKind.SPACER if raw.startswith("s") and raw[1:].isdigit() else ElementKind.BLANK if raw in ("x", "y") else ElementKind.PORT
-            result.append(PlacedElement(
-                kind=kind, key=raw, row=current_row, col=col, variant=variant_name
-            ))
+            kind = (
+                ElementKind.SPACER
+                if raw.startswith("s") and raw[1:].isdigit()
+                else ElementKind.BLANK if raw in ("x", "y") else ElementKind.PORT
+            )
+            result.append(
+                PlacedElement(
+                    kind=kind, key=raw, row=current_row, col=col, variant=variant_name
+                )
+            )
             col += 1
         elif isinstance(raw, dict):
-            expanded = _expand_element(raw, canvas, variant_name, default_row=current_row, default_col=col)
+            expanded = _expand_element(
+                raw, canvas, variant_name, default_row=current_row, default_col=col
+            )
             result.extend(expanded)
             col += sum(el.col_span for el in expanded)
         else:
-            raise LayoutParseError(f"Element must be a string key or mapping, got {type(raw).__name__}.")
+            raise LayoutParseError(
+                f"Element must be a string key or mapping, got {type(raw).__name__}."
+            )
     row_cursors[current_row] = col
     return result, row_cursors
 
@@ -423,8 +437,9 @@ def _expand_sequence(
       prefix: "gigabitethernet0-"
       start: 1             # first port number (default: 1)
       count: 24            # how many ports
-      pattern: odd         # "odd" | "even" | "all"
+      pattern: top-odd  # "top-odd" | "top-even" | "all"
       step: 1              # increment between ports (default: 1)
+      row: 1               # for pattern: all only — target row (default: 1)
     """
     if not isinstance(seq, dict):
         raise LayoutParseError("'sequence' must be a mapping.")
@@ -438,7 +453,10 @@ def _expand_sequence(
     start = int(seq.get("start", 1))
     count = int(seq.get("count", 1))
     step = int(seq.get("step", 1))
-    pattern = seq.get("pattern", "odd")
+    pattern = seq.get("pattern", "top-odd")
+    explicit_row = seq.get("row", None)
+    if explicit_row is not None:
+        explicit_row = int(explicit_row)
 
     # Generate port numbers
     port_numbers = [start + i * step for i in range(count)]
@@ -447,20 +465,29 @@ def _expand_sequence(
     row_cursors = dict(row_cursors)  # copy
 
     if pattern == "all":
-        # All ports in a single row (patch-panel style)
-        row = _single_active_row(row_cursors, canvas)
+        # All ports in a single row (patch-panel style).
+        # The target row defaults to 1 but can be overridden with `row:`.
+        row = (
+            explicit_row
+            if explicit_row is not None
+            else _single_active_row(row_cursors, canvas)
+        )
         col = row_cursors.get(row, 1)
         for n in port_numbers:
             key = f"{prefix}{n}"
-            result.append(PlacedElement(kind=kind, key=key, row=row, col=col, variant=variant_name))
+            result.append(
+                PlacedElement(
+                    kind=kind, key=key, row=row, col=col, variant=variant_name
+                )
+            )
             col += 1
         row_cursors[row] = col
 
-    elif pattern in ("odd", "even"):
+    elif pattern in ("top-odd", "top-even"):
         # Two-row layout: odd ports in row 1, even ports in row 2
-        # (or swapped for "even" pattern — useful when even ports are physically on top)
+        # (or swapped for "top-even" pattern — useful when even ports are physically on top)
         row1, row2 = (1, 2) if canvas.rows >= 2 else (1, 1)
-        if pattern == "even":
+        if pattern == "top-even":
             row1, row2 = row2, row1
 
         # Find the starting column (max of the two row cursors to keep alignment)
@@ -470,10 +497,18 @@ def _expand_sequence(
         for n in port_numbers:
             key = f"{prefix}{n}"
             if n % 2 == 1:  # odd
-                result.append(PlacedElement(kind=kind, key=key, row=row1, col=col1, variant=variant_name))
+                result.append(
+                    PlacedElement(
+                        kind=kind, key=key, row=row1, col=col1, variant=variant_name
+                    )
+                )
                 col1 += 1
             else:  # even
-                result.append(PlacedElement(kind=kind, key=key, row=row2, col=col2, variant=variant_name))
+                result.append(
+                    PlacedElement(
+                        kind=kind, key=key, row=row2, col=col2, variant=variant_name
+                    )
+                )
                 col2 += 1
 
         # Both cursors advance to the same column
@@ -482,7 +517,9 @@ def _expand_sequence(
         row_cursors[row2] = final_col
 
     else:
-        raise LayoutParseError(f"Unknown sequence pattern: {pattern!r}. Use 'odd', 'even', or 'all'.")
+        raise LayoutParseError(
+            f"Unknown sequence pattern: {pattern!r}. Use 'top-odd', 'top-even', or 'all'."
+        )
 
     return result, row_cursors
 
@@ -513,7 +550,12 @@ def _expand_group(
         if i > 0:
             # Insert spacer between sections
             spacer_els, row_cursors = _insert_filler(
-                ElementKind.SPACER, spacer_width, row_cursors, canvas, variant_name, prefix="s"
+                ElementKind.SPACER,
+                spacer_width,
+                row_cursors,
+                canvas,
+                variant_name,
+                prefix="s",
             )
             result.extend(spacer_els)
 
@@ -521,18 +563,26 @@ def _expand_group(
             raise LayoutParseError("Group section must be a mapping.")
 
         if "sequence" in section:
-            els, row_cursors = _expand_sequence(section["sequence"], row_cursors, canvas, variant_name)
+            els, row_cursors = _expand_sequence(
+                section["sequence"], row_cursors, canvas, variant_name
+            )
             result.extend(els)
         elif "elements" in section:
             row = _single_active_row(row_cursors, canvas)
-            els, row_cursors = _compile_explicit_row(section["elements"], row_cursors, row, canvas, variant_name)
+            els, row_cursors = _compile_explicit_row(
+                section["elements"], row_cursors, row, canvas, variant_name
+            )
             result.extend(els)
         elif "blank" in section:
             n = int(section["blank"])
-            els, row_cursors = _insert_filler(ElementKind.BLANK, n, row_cursors, canvas, variant_name, prefix="x")
+            els, row_cursors = _insert_filler(
+                ElementKind.BLANK, n, row_cursors, canvas, variant_name, prefix="x"
+            )
             result.extend(els)
         else:
-            raise LayoutParseError(f"Unknown group section keys: {list(section.keys())}.")
+            raise LayoutParseError(
+                f"Unknown group section keys: {list(section.keys())}."
+            )
 
     return result, row_cursors
 
@@ -556,19 +606,21 @@ def _insert_filler(
         key = f"{prefix}{col}"
         if canvas.rows >= 2:
             # One element spanning all rows
-            result.append(PlacedElement(
-                kind=kind,
-                key=key,
-                row=1,
-                col=col,
-                row_span=canvas.rows,
-                col_span=1,
-                variant=variant_name,
-            ))
+            result.append(
+                PlacedElement(
+                    kind=kind,
+                    key=key,
+                    row=1,
+                    col=col,
+                    row_span=canvas.rows,
+                    col_span=1,
+                    variant=variant_name,
+                )
+            )
         else:
-            result.append(PlacedElement(
-                kind=kind, key=key, row=1, col=col, variant=variant_name
-            ))
+            result.append(
+                PlacedElement(kind=kind, key=key, row=1, col=col, variant=variant_name)
+            )
 
     # Advance all row cursors
     new_col = start_col + count
@@ -614,18 +666,20 @@ def _expand_element(
     face_map = {"front": Face.FRONT, "rear": Face.REAR, "both": Face.BOTH}
     face = face_map.get(face_str, Face.BOTH)
 
-    return [PlacedElement(
-        kind=kind,
-        key=key,
-        face=face,
-        row=row,
-        col=col,
-        row_span=row_span,
-        col_span=col_span,
-        label=label,
-        css_classes=list(css_classes),
-        variant=variant_name,
-    )]
+    return [
+        PlacedElement(
+            kind=kind,
+            key=key,
+            face=face,
+            row=row,
+            col=col,
+            row_span=row_span,
+            col_span=col_span,
+            label=label,
+            css_classes=list(css_classes),
+            variant=variant_name,
+        )
+    ]
 
 
 def _single_active_row(row_cursors: dict[int, int], canvas: CanvasConfig) -> int:

--- a/netbox_device_view/layout/renderers/css_grid.py
+++ b/netbox_device_view/layout/renderers/css_grid.py
@@ -25,9 +25,13 @@ Selector conventions (must match the Django templates):
 
 from __future__ import annotations
 
-from typing import Optional
 
-from ..model import CanvasConfig, ElementKind, Face, LayoutView, NormalizedLayout, PlacedElement
+from ..model import (
+    CanvasConfig,
+    LayoutView,
+    NormalizedLayout,
+    PlacedElement,
+)
 
 
 def render(layout: NormalizedLayout) -> str:

--- a/netbox_device_view/layout/renderers/css_grid.py
+++ b/netbox_device_view/layout/renderers/css_grid.py
@@ -1,0 +1,171 @@
+"""
+CSS Grid renderer.
+
+Converts a NormalizedLayout (from either the YAML parser or the legacy
+adapter) into CSS text that is functionally equivalent to the hand-written
+CSS in the legacy grid_template_area field.
+
+The output CSS is injected verbatim into a <style> block by the templates,
+exactly as the legacy CSS was.  This means the renderer must produce valid
+CSS that the existing deviceview.html / ports.html templates understand.
+
+Rendering path
+--------------
+  NormalizedLayout
+      └─ LayoutView  (front / rear)
+              └─ PlacedElement[]    →   CSS grid-template-areas string
+              └─ variants           →   .deviceview.module<Name>.area { … }
+
+Selector conventions (must match the Django templates):
+  .deviceview.area           — default view (front or single-face)
+  .deviceview.area.dFront    — explicit front face (patch panels)
+  .deviceview.area.dRear     — explicit rear face (patch panels)
+  .deviceview.module<X>.area — module variant overlay
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ..model import CanvasConfig, ElementKind, Face, LayoutView, NormalizedLayout, PlacedElement
+
+
+def render(layout: NormalizedLayout) -> str:
+    """
+    Render a NormalizedLayout to a CSS string ready for injection into a
+    <style> block.
+
+    Returns a string that can be stored in / used as a replacement for the
+    legacy ``grid_template_area`` field.
+    """
+    parts: list[str] = []
+
+    if layout.has_separate_faces():
+        # Patch-panel style: front and rear are separate selectors
+        if layout.front:
+            parts.append(_render_view(layout.front, selector_suffix=".dFront"))
+        if layout.rear:
+            parts.append(_render_view(layout.rear, selector_suffix=".dRear"))
+    else:
+        # Single-face device (switch, router, firewall)
+        view = layout.front or layout.rear
+        if view:
+            parts.append(_render_view(view, selector_suffix=""))
+            # Render variants for this view
+            for variant_name, variant_elements in view.variants.items():
+                parts.append(_render_variant(view, variant_name, variant_elements))
+
+    return "\n".join(parts)
+
+
+# ── Private helpers ────────────────────────────────────────────────────────────
+
+
+def _render_view(view: LayoutView, selector_suffix: str) -> str:
+    """Render a single LayoutView to a CSS block."""
+    selector = f".deviceview.area{selector_suffix}"
+    grid_areas = _elements_to_grid_template_areas(view.elements, view.canvas)
+    return _build_css_block(selector, view.canvas, grid_areas)
+
+
+def _render_variant(
+    base_view: LayoutView,
+    variant_name: str,
+    variant_elements: list[PlacedElement],
+) -> str:
+    """Render a module variant overlay CSS block."""
+    # Merge base + variant elements, variant wins on key conflicts
+    merged: dict[str, PlacedElement] = {el.key: el for el in base_view.elements}
+    for el in variant_elements:
+        merged[el.key] = el
+    all_elements = list(merged.values())
+
+    selector = f".deviceview.module{variant_name}.area"
+    grid_areas = _elements_to_grid_template_areas(all_elements, base_view.canvas)
+    return _build_css_block(selector, base_view.canvas, grid_areas)
+
+
+def _build_css_block(
+    selector: str,
+    canvas: CanvasConfig,
+    grid_areas: list[str],
+) -> str:
+    """Build a complete CSS rule block."""
+    lines: list[str] = [f"{selector} {{"]
+
+    if canvas.background:
+        lines.append(f"    background-color: {canvas.background};")
+
+    # Patch-panel views use auto sizing; standard views use fixed 20px cells
+    if _is_patch_panel_canvas(canvas):
+        lines.append("    grid-auto-rows: auto;")
+        lines.append("    grid-auto-columns: auto;")
+
+    if grid_areas:
+        area_lines = "\n".join(f'        "{row}"' for row in grid_areas)
+        lines.append(f"    grid-template-areas:\n{area_lines};")
+
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _elements_to_grid_template_areas(
+    elements: list[PlacedElement],
+    canvas: CanvasConfig,
+) -> list[str]:
+    """
+    Convert a flat list of PlacedElement objects into CSS grid-template-areas
+    row strings.
+
+    The algorithm:
+    1. Build a 2D grid (rows × cols) filled with "." (empty).
+    2. Place each element's key into its cell(s).
+    3. For elements spanning multiple rows/cols, fill all spanned cells with
+       the same key (CSS grid-template-areas requires this).
+    4. Convert each row to a space-separated string of area names.
+
+    CSS grid-template-areas does NOT allow a cell to be empty (".") unless
+    ALL cells in that column are empty — we replace empty cells with the
+    nearest spacer/blank key or a generated placeholder.
+    """
+    rows = canvas.rows
+    cols = canvas.columns
+
+    # grid[row][col] = area name ("." = empty)
+    grid: list[list[str]] = [["." for _ in range(cols)] for _ in range(rows)]
+
+    # Sort elements to place in a predictable order
+    sorted_elements = sorted(elements, key=lambda e: (e.row, e.col))
+
+    for el in sorted_elements:
+        r_start = el.row - 1  # convert to 0-based
+        c_start = el.col - 1
+        r_end = r_start + el.row_span
+        c_end = c_start + el.col_span
+
+        # Clamp to canvas bounds
+        r_end = min(r_end, rows)
+        c_end = min(c_end, cols)
+
+        for r in range(r_start, r_end):
+            for c in range(c_start, c_end):
+                if 0 <= r < rows and 0 <= c < cols:
+                    grid[r][c] = el.key
+
+    # Replace remaining "." placeholders with unique generated names
+    # CSS grid-template-areas requires that named areas form a contiguous
+    # rectangle; a lone "." in the middle can sometimes be a problem, but
+    # browsers handle it.  We leave them as "." for simplicity.
+
+    return [" ".join(row) for row in grid]
+
+
+def _is_patch_panel_canvas(canvas: CanvasConfig) -> bool:
+    """
+    Heuristic: if the canvas rows == 1 or auto sizing was requested
+    (indicated by cell_size == 0, a sentinel), treat as patch-panel.
+
+    In practice we detect patch panels by the face selector (.dFront/.dRear)
+    rather than the canvas config, but this provides a fallback.
+    """
+    return canvas.cell_size == 0

--- a/netbox_device_view/migrations/0003_deviceview_yaml_layout.py
+++ b/netbox_device_view/migrations/0003_deviceview_yaml_layout.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("netbox_device_view", "0002_alter_deviceview_device_type"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="deviceview",
+            name="yaml_layout",
+            field=models.TextField(
+                blank=True,
+                default="",
+                help_text=(
+                    "YAML-based layout definition. When provided, this takes precedence over "
+                    "the legacy CSS grid_template_area field for rendering. "
+                    "See the documentation for the schema reference."
+                ),
+            ),
+        ),
+    ]

--- a/netbox_device_view/models.py
+++ b/netbox_device_view/models.py
@@ -12,8 +12,23 @@ class DeviceView(NetBoxModel):
 
     grid_template_area = models.TextField(blank=False)
 
+    yaml_layout = models.TextField(
+        blank=True,
+        default="",
+        help_text=(
+            "YAML-based layout definition. When provided, this takes precedence over "
+            "the legacy CSS grid_template_area field for rendering. "
+            "See the documentation for the schema reference."
+        ),
+    )
+
     class Meta:
         ordering = ("device_type",)
 
     def __str__(self):
         return self.device_type.model
+
+    @property
+    def has_yaml_layout(self):
+        """Return True if a YAML layout is defined for this device view."""
+        return bool(self.yaml_layout and self.yaml_layout.strip())

--- a/netbox_device_view/utils.py
+++ b/netbox_device_view/utils.py
@@ -10,6 +10,7 @@ from dcim.models import (
     RearPortTemplate,
 )
 
+from .layout import get_css_for_device_view
 from .models import DeviceView
 
 
@@ -164,7 +165,7 @@ def prepare(obj):
     try:
         if obj.virtual_chassis is None:
             device_view = DeviceView.objects.get(device_type=obj.device_type)
-            dv[1] = device_view.grid_template_area
+            dv[1] = get_css_for_device_view(device_view)
             modules[1] = obj.modules.all()
             ports_chassis = process_interfaces(
                 obj.interfaces.all(), ports_chassis, obj.name
@@ -179,12 +180,12 @@ def prepare(obj):
         else:
             for member in obj.virtual_chassis.members.all():
                 pos = member.vc_position
+                member_view = DeviceView.objects.get(device_type=member.device_type)
+                member_css = get_css_for_device_view(member_view)
                 dv[pos] = re.sub(
                     r"\.area\b",
                     f".area.d{pos}",
-                    DeviceView.objects.get(
-                        device_type=member.device_type
-                    ).grid_template_area,
+                    member_css,
                 )
                 modules[member.vc_position] = member.modules.all()
                 ports_chassis = process_interfaces(

--- a/tests/test_layout_parser.py
+++ b/tests/test_layout_parser.py
@@ -1,0 +1,606 @@
+"""
+Tests for netbox_device_view.layout.parser
+
+These are pure unit tests — no Django, no DB, no NetBox required.
+"""
+
+import pytest
+
+from netbox_device_view.layout.model import (
+    CanvasConfig,
+    ElementKind,
+    Face,
+)
+from netbox_device_view.layout.parser import (
+    LayoutParseError,
+    parse,
+    validate,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse(yaml_text: str):
+    """Parse yaml_text and return a NormalizedLayout."""
+    return parse(yaml_text)
+
+
+# ---------------------------------------------------------------------------
+# Version handling
+# ---------------------------------------------------------------------------
+
+
+class TestVersion:
+    def test_version_1_accepted(self):
+        layout = _parse("version: 1\nviews: {}")
+        assert layout.source == "yaml"
+
+    def test_missing_version_defaults_to_1(self):
+        layout = _parse("views: {}")
+        assert layout.source == "yaml"
+
+    def test_unsupported_version_raises(self):
+        with pytest.raises(LayoutParseError, match="Unsupported layout version"):
+            _parse("version: 99\nviews: {}")
+
+    def test_non_mapping_raises(self):
+        with pytest.raises(LayoutParseError, match="must be a YAML mapping"):
+            _parse("- item1\n- item2")
+
+    def test_invalid_yaml_raises(self):
+        with pytest.raises(LayoutParseError, match="Invalid YAML"):
+            _parse("key: [unclosed")
+
+
+# ---------------------------------------------------------------------------
+# Meta / description
+# ---------------------------------------------------------------------------
+
+
+class TestMeta:
+    def test_description_captured(self):
+        layout = _parse('version: 1\nmeta:\n  description: "My Device"\nviews: {}')
+        assert layout.description == "My Device"
+
+    def test_no_meta_gives_empty_description(self):
+        layout = _parse("version: 1\nviews: {}")
+        assert layout.description == ""
+
+    def test_global_background(self):
+        yaml = """
+version: 1
+meta:
+  background: "#aabbcc"
+canvas:
+  columns: 4
+  rows: 1
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 4
+          pattern: all
+"""
+        layout = _parse(yaml)
+        assert layout.front is not None
+        assert layout.front.canvas.background == "#aabbcc"
+
+
+# ---------------------------------------------------------------------------
+# Canvas defaults and override
+# ---------------------------------------------------------------------------
+
+
+class TestCanvas:
+    def test_defaults(self):
+        layout = _parse("version: 1\nviews: {}")
+        # No views → no canvas to test; but parse should not fail
+        assert layout is not None
+
+    def test_canvas_columns_rows(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 8
+  rows: 1
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 4
+          pattern: all
+"""
+        layout = _parse(yaml)
+        assert layout.front.canvas.columns == 8
+        assert layout.front.canvas.rows == 1
+
+    def test_canvas_background_propagates(self):
+        yaml = """
+version: 1
+canvas:
+  background: "#ff0000"
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 2
+          pattern: all
+"""
+        layout = _parse(yaml)
+        assert layout.front.canvas.background == "#ff0000"
+
+
+# ---------------------------------------------------------------------------
+# Face parsing
+# ---------------------------------------------------------------------------
+
+
+class TestFaceParsing:
+    def test_front_view(self):
+        yaml = "version: 1\nviews:\n  front:\n    rows: []\n"
+        layout = _parse(yaml)
+        assert "front" in layout.views
+        assert layout.views["front"].face == Face.FRONT
+
+    def test_rear_view(self):
+        yaml = "version: 1\nviews:\n  rear:\n    rows: []\n"
+        layout = _parse(yaml)
+        assert "rear" in layout.views
+        assert layout.views["rear"].face == Face.REAR
+
+    def test_has_separate_faces_both(self):
+        yaml = "version: 1\nviews:\n  front:\n    rows: []\n  rear:\n    rows: []\n"
+        layout = _parse(yaml)
+        assert layout.has_separate_faces()
+
+    def test_has_separate_faces_front_only(self):
+        yaml = "version: 1\nviews:\n  front:\n    rows: []\n"
+        layout = _parse(yaml)
+        assert not layout.has_separate_faces()
+
+
+# ---------------------------------------------------------------------------
+# Sequence expansion — pattern: all
+# ---------------------------------------------------------------------------
+
+
+SIMPLE_ALL_YAML = """
+version: 1
+canvas:
+  columns: 6
+  rows: 1
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "port-"
+          start: 1
+          count: 6
+          pattern: all
+"""
+
+
+class TestSequenceAll:
+    def setup_method(self):
+        self.layout = _parse(SIMPLE_ALL_YAML)
+        self.elements = self.layout.front.elements
+
+    def test_count(self):
+        assert len(self.elements) == 6
+
+    def test_keys(self):
+        keys = [e.key for e in self.elements]
+        assert keys == ["port-1", "port-2", "port-3", "port-4", "port-5", "port-6"]
+
+    def test_all_in_row_1(self):
+        assert all(e.row == 1 for e in self.elements)
+
+    def test_sequential_columns(self):
+        cols = [e.col for e in sorted(self.elements, key=lambda e: e.key)]
+        assert cols == list(range(1, 7))
+
+    def test_kind_is_port(self):
+        assert all(e.kind == ElementKind.PORT for e in self.elements)
+
+
+# ---------------------------------------------------------------------------
+# Sequence expansion — pattern: odd (2-row Cisco style)
+# ---------------------------------------------------------------------------
+
+
+ODD_YAML = """
+version: 1
+canvas:
+  columns: 12
+  rows: 2
+views:
+  front:
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "gi0-"
+          start: 1
+          count: 12
+          pattern: odd
+"""
+
+
+class TestSequenceOdd:
+    def setup_method(self):
+        self.layout = _parse(ODD_YAML)
+        self.elements = self.layout.front.elements
+
+    def test_count(self):
+        assert len(self.elements) == 12
+
+    def test_odd_ports_in_row_1(self):
+        odd_els = [e for e in self.elements if int(e.key.split("-")[1]) % 2 == 1]
+        assert all(e.row == 1 for e in odd_els)
+
+    def test_even_ports_in_row_2(self):
+        even_els = [e for e in self.elements if int(e.key.split("-")[1]) % 2 == 0]
+        assert all(e.row == 2 for e in even_els)
+
+    def test_kind_is_interface(self):
+        assert all(e.kind == ElementKind.INTERFACE for e in self.elements)
+
+
+# ---------------------------------------------------------------------------
+# Sequence expansion — pattern: even
+# ---------------------------------------------------------------------------
+
+
+EVEN_YAML = """
+version: 1
+canvas:
+  columns: 6
+  rows: 2
+views:
+  front:
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "gi0-"
+          start: 1
+          count: 6
+          pattern: even
+"""
+
+
+class TestSequenceEven:
+    def setup_method(self):
+        self.layout = _parse(EVEN_YAML)
+        self.elements = self.layout.front.elements
+
+    def test_even_ports_in_row_1(self):
+        # "even" pattern: even-numbered ports go in row 1
+        even_els = [e for e in self.elements if int(e.key.split("-")[1]) % 2 == 0]
+        assert all(e.row == 1 for e in even_els)
+
+    def test_odd_ports_in_row_2(self):
+        odd_els = [e for e in self.elements if int(e.key.split("-")[1]) % 2 == 1]
+        assert all(e.row == 2 for e in odd_els)
+
+
+# ---------------------------------------------------------------------------
+# Unknown pattern raises
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownPattern:
+    def test_raises(self):
+        yaml = """
+version: 1
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 2
+          pattern: diagonal
+"""
+        with pytest.raises(LayoutParseError, match="Unknown sequence pattern"):
+            _parse(yaml)
+
+
+# ---------------------------------------------------------------------------
+# Spacer / blank insertion
+# ---------------------------------------------------------------------------
+
+
+class TestSpacerBlank:
+    def test_spacer_spans_all_rows(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 4
+  rows: 2
+views:
+  front:
+    rows:
+      - spacer: 2
+"""
+        layout = _parse(yaml)
+        spacers = [e for e in layout.front.elements if e.kind == ElementKind.SPACER]
+        assert len(spacers) == 2
+        # Each spacer should span all canvas rows (row_span == 2)
+        assert all(e.row_span == 2 for e in spacers)
+
+    def test_blank_spans_all_rows(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 4
+  rows: 2
+views:
+  front:
+    rows:
+      - blank: 3
+"""
+        layout = _parse(yaml)
+        blanks = [e for e in layout.front.elements if e.kind == ElementKind.BLANK]
+        assert len(blanks) == 3
+        assert all(e.row_span == 2 for e in blanks)
+
+
+# ---------------------------------------------------------------------------
+# Group
+# ---------------------------------------------------------------------------
+
+
+class TestGroup:
+    def test_group_inserts_spacer_between_sections(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 8
+  rows: 1
+views:
+  front:
+    rows:
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: port
+                prefix: "p"
+                start: 1
+                count: 3
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "p"
+                start: 4
+                count: 3
+                pattern: all
+"""
+        layout = _parse(yaml)
+        elements = layout.front.elements
+        spacers = [e for e in elements if e.kind == ElementKind.SPACER]
+        ports = [e for e in elements if e.kind == ElementKind.PORT]
+        assert len(ports) == 6
+        assert len(spacers) == 1
+
+    def test_group_column_ordering(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 5
+  rows: 1
+views:
+  front:
+    rows:
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: port
+                prefix: "p"
+                start: 1
+                count: 2
+                pattern: all
+            - sequence:
+                kind: port
+                prefix: "p"
+                start: 3
+                count: 2
+                pattern: all
+"""
+        layout = _parse(yaml)
+        ports = sorted(
+            [e for e in layout.front.elements if e.kind == ElementKind.PORT],
+            key=lambda e: e.col,
+        )
+        spacers = [e for e in layout.front.elements if e.kind == ElementKind.SPACER]
+        # ports at cols 1,2; spacer at col 3; ports at cols 4,5
+        assert ports[0].col == 1
+        assert ports[1].col == 2
+        assert spacers[0].col == 3
+        assert ports[2].col == 4
+        assert ports[3].col == 5
+
+
+# ---------------------------------------------------------------------------
+# copy_from
+# ---------------------------------------------------------------------------
+
+
+class TestCopyFrom:
+    def test_copy_from_front_to_rear(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 4
+  rows: 1
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 4
+          pattern: all
+  rear:
+    copy_from: front
+"""
+        layout = _parse(yaml)
+        assert layout.has_separate_faces()
+        front_keys = {e.key for e in layout.front.elements}
+        rear_keys = {e.key for e in layout.rear.elements}
+        assert front_keys == rear_keys
+
+    def test_copy_from_nonexistent_raises(self):
+        yaml = """
+version: 1
+views:
+  rear:
+    copy_from: nonexistent
+"""
+        with pytest.raises(LayoutParseError, match="copy_from"):
+            _parse(yaml)
+
+
+# ---------------------------------------------------------------------------
+# Variants
+# ---------------------------------------------------------------------------
+
+
+class TestVariants:
+    YAML = """
+version: 1
+canvas:
+  columns: 14
+  rows: 2
+views:
+  front:
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "gi0-"
+          start: 1
+          count: 6
+          pattern: odd
+
+variants:
+  NM-8X:
+    match: module
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "te1-"
+          start: 1
+          count: 8
+          pattern: odd
+"""
+
+    def setup_method(self):
+        self.layout = _parse(self.YAML)
+
+    def test_base_elements_present(self):
+        assert len(self.layout.front.elements) == 6
+
+    def test_variant_registered(self):
+        assert "NM-8X" in self.layout.front.variants
+
+    def test_variant_elements_count(self):
+        assert len(self.layout.front.variants["NM-8X"]) == 8
+
+    def test_elements_for_variant_includes_both(self):
+        all_els = self.layout.front.elements_for_variant("NM-8X")
+        keys = {e.key for e in all_els}
+        assert "gi0-1" in keys
+        assert "te1-1" in keys
+
+
+# ---------------------------------------------------------------------------
+# Flat elements (explicit at:/span: coordinates)
+# ---------------------------------------------------------------------------
+
+
+class TestFlatElements:
+    def test_flat_elements_placed(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 4
+  rows: 2
+views:
+  front:
+    elements:
+      - kind: port
+        key: "p1"
+        at: {row: 1, col: 1}
+      - kind: port
+        key: "p2"
+        at: {row: 2, col: 1}
+      - kind: spacer
+        at: {row: 1, col: 2}
+        span: {rows: 2, cols: 1}
+"""
+        layout = _parse(yaml)
+        els = {e.key: e for e in layout.front.elements}
+        assert "p1" in els
+        assert "p2" in els
+        assert els["p1"].row == 1
+        assert els["p2"].row == 2
+
+    def test_flat_port_missing_key_raises(self):
+        yaml = """
+version: 1
+views:
+  front:
+    elements:
+      - kind: port
+        at: {row: 1, col: 1}
+"""
+        with pytest.raises(LayoutParseError, match="must have a 'key'"):
+            _parse(yaml)
+
+    def test_unknown_kind_raises(self):
+        yaml = """
+version: 1
+views:
+  front:
+    elements:
+      - kind: fluxcapacitor
+        key: "foo"
+"""
+        with pytest.raises(LayoutParseError, match="Unknown element kind"):
+            _parse(yaml)
+
+
+# ---------------------------------------------------------------------------
+# validate() helper
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def test_valid_returns_empty_list(self):
+        yaml = "version: 1\nviews: {}"
+        errors = validate(yaml)
+        assert errors == []
+
+    def test_invalid_returns_errors(self):
+        errors = validate("version: 99\nviews: {}")
+        assert len(errors) > 0
+        assert any("Unsupported" in e for e in errors)
+
+    def test_bad_yaml_returns_errors(self):
+        errors = validate("key: [unclosed")
+        assert len(errors) > 0

--- a/tests/test_layout_parser.py
+++ b/tests/test_layout_parser.py
@@ -7,7 +7,6 @@ These are pure unit tests — no Django, no DB, no NetBox required.
 import pytest
 
 from netbox_device_view.layout.model import (
-    CanvasConfig,
     ElementKind,
     Face,
 )
@@ -16,7 +15,6 @@ from netbox_device_view.layout.parser import (
     parse,
     validate,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -217,7 +215,50 @@ class TestSequenceAll:
 
 
 # ---------------------------------------------------------------------------
-# Sequence expansion — pattern: odd (2-row Cisco style)
+# Sequence expansion — pattern: all with explicit row: 2
+# ---------------------------------------------------------------------------
+
+
+ALL_ROW2_YAML = """
+version: 1
+canvas:
+  columns: 6
+  rows: 2
+views:
+  front:
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "uplink-"
+          start: 1
+          count: 4
+          pattern: all
+          row: 2
+"""
+
+
+class TestSequenceAllRow2:
+    def setup_method(self):
+        self.layout = _parse(ALL_ROW2_YAML)
+        self.elements = self.layout.front.elements
+
+    def test_count(self):
+        assert len(self.elements) == 4
+
+    def test_all_in_row_2(self):
+        assert all(e.row == 2 for e in self.elements)
+
+    def test_sequential_columns(self):
+        cols = sorted(e.col for e in self.elements)
+        assert cols == [1, 2, 3, 4]
+
+    def test_keys(self):
+        keys = [e.key for e in self.elements]
+        assert keys == ["uplink-1", "uplink-2", "uplink-3", "uplink-4"]
+
+
+# ---------------------------------------------------------------------------
+# Sequence expansion — pattern: top-odd (2-row Cisco style)
 # ---------------------------------------------------------------------------
 
 
@@ -234,7 +275,7 @@ views:
           prefix: "gi0-"
           start: 1
           count: 12
-          pattern: odd
+          pattern: top-odd
 """
 
 
@@ -259,7 +300,7 @@ class TestSequenceOdd:
 
 
 # ---------------------------------------------------------------------------
-# Sequence expansion — pattern: even
+# Sequence expansion — pattern: top-even
 # ---------------------------------------------------------------------------
 
 
@@ -276,7 +317,7 @@ views:
           prefix: "gi0-"
           start: 1
           count: 6
-          pattern: even
+          pattern: top-even
 """
 
 
@@ -286,7 +327,7 @@ class TestSequenceEven:
         self.elements = self.layout.front.elements
 
     def test_even_ports_in_row_1(self):
-        # "even" pattern: even-numbered ports go in row 1
+        # "even" pattern: top-even-numbered ports go in row 1
         even_els = [e for e in self.elements if int(e.key.split("-")[1]) % 2 == 0]
         assert all(e.row == 1 for e in even_els)
 
@@ -495,7 +536,7 @@ views:
           prefix: "gi0-"
           start: 1
           count: 6
-          pattern: odd
+          pattern: top-odd
 
 variants:
   NM-8X:
@@ -506,7 +547,7 @@ variants:
           prefix: "te1-"
           start: 1
           count: 8
-          pattern: odd
+          pattern: top-odd
 """
 
     def setup_method(self):

--- a/tests/test_layout_renderer.py
+++ b/tests/test_layout_renderer.py
@@ -1,0 +1,514 @@
+"""
+Tests for netbox_device_view.layout.renderers.css_grid
+
+These are pure unit tests — no Django, no DB, no NetBox required.
+"""
+
+import pytest
+
+from netbox_device_view.layout.parser import parse
+from netbox_device_view.layout.renderers.css_grid import render
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _render(yaml_text: str) -> str:
+    return render(parse(yaml_text))
+
+
+def _lines(css: str) -> list[str]:
+    return [l.strip() for l in css.splitlines() if l.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Selector conventions
+# ---------------------------------------------------------------------------
+
+
+class TestSelectors:
+    def test_single_face_uses_plain_area_selector(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 4
+  rows: 1
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 4
+          pattern: all
+"""
+        css = _render(yaml)
+        assert ".deviceview.area {" in css
+        assert ".dFront" not in css
+        assert ".dRear" not in css
+
+    def test_patch_panel_uses_dFront_dRear_selectors(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 4
+  rows: 1
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 4
+          pattern: all
+  rear:
+    copy_from: front
+"""
+        css = _render(yaml)
+        assert ".deviceview.area.dFront {" in css
+        assert ".deviceview.area.dRear {" in css
+
+    def test_variant_selector(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 8
+  rows: 2
+views:
+  front:
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "gi0-"
+          start: 1
+          count: 4
+          pattern: odd
+variants:
+  NM-4X:
+    match: module
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "te1-"
+          start: 1
+          count: 4
+          pattern: odd
+"""
+        css = _render(yaml)
+        assert ".deviceview.moduleNM-4X.area {" in css
+
+
+# ---------------------------------------------------------------------------
+# grid-template-areas content
+# ---------------------------------------------------------------------------
+
+
+class TestGridTemplateAreas:
+    def test_single_row_all_ports_present(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 4
+  rows: 1
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 4
+          pattern: all
+"""
+        css = _render(yaml)
+        assert "p1" in css
+        assert "p2" in css
+        assert "p3" in css
+        assert "p4" in css
+
+    def test_two_row_odd_pattern_row_structure(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 4
+  rows: 2
+views:
+  front:
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "gi-"
+          start: 1
+          count: 4
+          pattern: odd
+"""
+        css = _render(yaml)
+        # Extract the two grid-template-areas rows
+        in_areas = False
+        area_rows = []
+        for line in css.splitlines():
+            stripped = line.strip()
+            if "grid-template-areas" in stripped:
+                in_areas = True
+                continue
+            if in_areas and stripped.startswith('"'):
+                area_rows.append(stripped.strip('"').strip(';').strip())
+            elif in_areas and stripped == "}":
+                break
+
+        assert len(area_rows) == 2
+        row1, row2 = area_rows
+        # Odd ports (gi-1, gi-3) should appear in row 1
+        assert "gi-1" in row1
+        assert "gi-3" in row1
+        # Even ports (gi-2, gi-4) should appear in row 2
+        assert "gi-2" in row2
+        assert "gi-4" in row2
+
+    def test_spacer_appears_in_output(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 3
+  rows: 1
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 2
+          pattern: all
+      - spacer: 1
+"""
+        css = _render(yaml)
+        # A spacer key (s-something) should appear in the areas
+        assert "grid-template-areas" in css
+        # At least one cell that is not a port key
+        lines_with_areas = [l for l in css.splitlines() if l.strip().startswith('"')]
+        row_content = " ".join(lines_with_areas)
+        cells = row_content.replace('"', '').split()
+        non_port_cells = [c for c in cells if not c.startswith("p")]
+        assert len(non_port_cells) > 0
+
+    def test_blank_fills_cells(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 4
+  rows: 1
+views:
+  front:
+    rows:
+      - blank: 2
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 2
+          pattern: all
+"""
+        css = _render(yaml)
+        assert "p1" in css
+        assert "p2" in css
+        # Blanks fill the first 2 columns — the area row should have 4 cells
+        lines_with_areas = [l for l in css.splitlines() if l.strip().startswith('"')]
+        cells = lines_with_areas[0].strip().strip('"').strip(';').split()
+        assert len(cells) == 4
+
+
+# ---------------------------------------------------------------------------
+# Background color
+# ---------------------------------------------------------------------------
+
+
+class TestBackground:
+    def test_background_color_emitted(self):
+        yaml = """
+version: 1
+meta:
+  background: "#d9d9d9"
+canvas:
+  columns: 2
+  rows: 1
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 2
+          pattern: all
+"""
+        css = _render(yaml)
+        assert "background-color: #d9d9d9" in css
+
+    def test_no_background_not_emitted(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 2
+  rows: 1
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 2
+          pattern: all
+"""
+        css = _render(yaml)
+        assert "background-color" not in css
+
+
+# ---------------------------------------------------------------------------
+# Patch-panel auto sizing
+# ---------------------------------------------------------------------------
+
+
+class TestPatchPanelSizing:
+    def test_patch_panel_has_grid_auto(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 4
+  rows: 1
+  cell_size: 0
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "p"
+          start: 1
+          count: 4
+          pattern: all
+  rear:
+    copy_from: front
+"""
+        css = _render(yaml)
+        assert "grid-auto-rows: auto" in css
+        assert "grid-auto-columns: auto" in css
+
+    def test_standard_switch_no_grid_auto(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 4
+  rows: 2
+views:
+  front:
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "gi-"
+          start: 1
+          count: 4
+          pattern: odd
+"""
+        css = _render(yaml)
+        assert "grid-auto-rows" not in css
+        assert "grid-auto-columns" not in css
+
+
+# ---------------------------------------------------------------------------
+# Variant merging
+# ---------------------------------------------------------------------------
+
+
+class TestVariantMerging:
+    def test_variant_css_contains_base_and_variant_ports(self):
+        """
+        When a variant rows block re-specifies the full layout (base + variant
+        ports), the rendered variant CSS block contains both port sets.
+        This matches the real-world pattern used in C9300-24T with C9300-NM-8X.
+        """
+        yaml = """
+version: 1
+canvas:
+  columns: 8
+  rows: 2
+views:
+  front:
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "gi0-"
+          start: 1
+          count: 4
+          pattern: odd
+variants:
+  NM-4X:
+    match: module
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "gi0-"
+          start: 1
+          count: 4
+          pattern: odd
+      - sequence:
+          kind: interface
+          prefix: "te1-"
+          start: 1
+          count: 4
+          pattern: odd
+"""
+        css = _render(yaml)
+        # Find the variant block
+        variant_start = css.index(".deviceview.moduleNM-4X.area")
+        variant_block = css[variant_start:]
+        assert "gi0-1" in variant_block
+        assert "te1-1" in variant_block
+
+    def test_base_block_does_not_contain_variant_ports(self):
+        yaml = """
+version: 1
+canvas:
+  columns: 8
+  rows: 2
+views:
+  front:
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "gi0-"
+          start: 1
+          count: 4
+          pattern: odd
+variants:
+  NM-4X:
+    match: module
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "gi0-"
+          start: 1
+          count: 4
+          pattern: odd
+      - sequence:
+          kind: interface
+          prefix: "te1-"
+          start: 1
+          count: 4
+          pattern: odd
+"""
+        css = _render(yaml)
+        # Base block ends before variant block
+        base_end = css.index(".deviceview.moduleNM-4X.area")
+        base_block = css[:base_end]
+        assert "te1-1" not in base_block
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: C9300-24T CSS equivalence
+# ---------------------------------------------------------------------------
+
+
+class TestC9300EndToEnd:
+    """Verify that the YAML for C9300-24T produces CSS with the expected keys."""
+
+    YAML = """
+version: 1
+meta:
+  description: "Cisco Catalyst 9300-24T"
+canvas:
+  columns: 32
+  rows: 2
+views:
+  front:
+    rows:
+      - blank: 14
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 1
+                count: 12
+                pattern: odd
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 13
+                count: 12
+                pattern: odd
+      - spacer: 4
+variants:
+  C9300-NM-8X:
+    match: module
+    rows:
+      - blank: 14
+      - group:
+          spacer: 1
+          sections:
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 1
+                count: 12
+                pattern: odd
+            - sequence:
+                kind: interface
+                prefix: "gigabitethernet0-"
+                start: 13
+                count: 12
+                pattern: odd
+            - sequence:
+                kind: interface
+                prefix: "tengigabitethernet1-"
+                start: 1
+                count: 8
+                pattern: odd
+"""
+
+    def setup_method(self):
+        self.css = _render(self.YAML)
+
+    def test_base_selector_present(self):
+        assert ".deviceview.area {" in self.css
+
+    def test_all_24_ge_ports_in_base(self):
+        base_end = self.css.find(".deviceview.moduleC9300-NM-8X.area")
+        base = self.css[:base_end] if base_end != -1 else self.css
+        for i in range(1, 25):
+            assert f"gigabitethernet0-{i}" in base
+
+    def test_variant_selector_present(self):
+        assert ".deviceview.moduleC9300-NM-8X.area {" in self.css
+
+    def test_variant_contains_10ge_ports(self):
+        variant_start = self.css.index(".deviceview.moduleC9300-NM-8X.area")
+        variant_block = self.css[variant_start:]
+        for i in range(1, 9):
+            assert f"tengigabitethernet1-{i}" in variant_block
+
+    def test_grid_has_correct_column_count(self):
+        """Each row of the base block should have exactly 32 cells."""
+        in_base = False
+        in_areas = False
+        area_rows = []
+        for line in self.css.splitlines():
+            s = line.strip()
+            if ".deviceview.area {" in s:
+                in_base = True
+            if in_base and "moduleC9300" in s:
+                break
+            if in_base and "grid-template-areas" in s:
+                in_areas = True
+                continue
+            if in_base and in_areas and s.startswith('"'):
+                cells = s.strip('"').rstrip(';').strip()
+                area_rows.append(cells.split())
+        assert len(area_rows) == 2
+        assert len(area_rows[0]) == 32
+        assert len(area_rows[1]) == 32

--- a/tests/test_layout_renderer.py
+++ b/tests/test_layout_renderer.py
@@ -4,11 +4,8 @@ Tests for netbox_device_view.layout.renderers.css_grid
 These are pure unit tests — no Django, no DB, no NetBox required.
 """
 
-import pytest
-
 from netbox_device_view.layout.parser import parse
 from netbox_device_view.layout.renderers.css_grid import render
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -20,7 +17,7 @@ def _render(yaml_text: str) -> str:
 
 
 def _lines(css: str) -> list[str]:
-    return [l.strip() for l in css.splitlines() if l.strip()]
+    return [line.strip() for line in css.splitlines() if line.strip()]
 
 
 # ---------------------------------------------------------------------------
@@ -86,7 +83,7 @@ views:
           prefix: "gi0-"
           start: 1
           count: 4
-          pattern: odd
+          pattern: top-odd
 variants:
   NM-4X:
     match: module
@@ -96,7 +93,7 @@ variants:
           prefix: "te1-"
           start: 1
           count: 4
-          pattern: odd
+          pattern: top-odd
 """
         css = _render(yaml)
         assert ".deviceview.moduleNM-4X.area {" in css
@@ -130,7 +127,7 @@ views:
         assert "p3" in css
         assert "p4" in css
 
-    def test_two_row_odd_pattern_row_structure(self):
+    def test_two_row_top_odd_pattern_row_structure(self):
         yaml = """
 version: 1
 canvas:
@@ -144,7 +141,7 @@ views:
           prefix: "gi-"
           start: 1
           count: 4
-          pattern: odd
+          pattern: top-odd
 """
         css = _render(yaml)
         # Extract the two grid-template-areas rows
@@ -156,7 +153,7 @@ views:
                 in_areas = True
                 continue
             if in_areas and stripped.startswith('"'):
-                area_rows.append(stripped.strip('"').strip(';').strip())
+                area_rows.append(stripped.strip('"').strip(";").strip())
             elif in_areas and stripped == "}":
                 break
 
@@ -190,9 +187,11 @@ views:
         # A spacer key (s-something) should appear in the areas
         assert "grid-template-areas" in css
         # At least one cell that is not a port key
-        lines_with_areas = [l for l in css.splitlines() if l.strip().startswith('"')]
+        lines_with_areas = [
+            line for line in css.splitlines() if line.strip().startswith('"')
+        ]
         row_content = " ".join(lines_with_areas)
-        cells = row_content.replace('"', '').split()
+        cells = row_content.replace('"', "").split()
         non_port_cells = [c for c in cells if not c.startswith("p")]
         assert len(non_port_cells) > 0
 
@@ -217,8 +216,10 @@ views:
         assert "p1" in css
         assert "p2" in css
         # Blanks fill the first 2 columns — the area row should have 4 cells
-        lines_with_areas = [l for l in css.splitlines() if l.strip().startswith('"')]
-        cells = lines_with_areas[0].strip().strip('"').strip(';').split()
+        lines_with_areas = [
+            line for line in css.splitlines() if line.strip().startswith('"')
+        ]
+        cells = lines_with_areas[0].strip().strip('"').strip(";").split()
         assert len(cells) == 4
 
 
@@ -312,7 +313,7 @@ views:
           prefix: "gi-"
           start: 1
           count: 4
-          pattern: odd
+          pattern: top-odd
 """
         css = _render(yaml)
         assert "grid-auto-rows" not in css
@@ -344,7 +345,7 @@ views:
           prefix: "gi0-"
           start: 1
           count: 4
-          pattern: odd
+          pattern: top-odd
 variants:
   NM-4X:
     match: module
@@ -354,13 +355,13 @@ variants:
           prefix: "gi0-"
           start: 1
           count: 4
-          pattern: odd
+          pattern: top-odd
       - sequence:
           kind: interface
           prefix: "te1-"
           start: 1
           count: 4
-          pattern: odd
+          pattern: top-odd
 """
         css = _render(yaml)
         # Find the variant block
@@ -383,7 +384,7 @@ views:
           prefix: "gi0-"
           start: 1
           count: 4
-          pattern: odd
+          pattern: top-odd
 variants:
   NM-4X:
     match: module
@@ -393,13 +394,13 @@ variants:
           prefix: "gi0-"
           start: 1
           count: 4
-          pattern: odd
+          pattern: top-odd
       - sequence:
           kind: interface
           prefix: "te1-"
           start: 1
           count: 4
-          pattern: odd
+          pattern: top-odd
 """
         css = _render(yaml)
         # Base block ends before variant block
@@ -435,13 +436,13 @@ views:
                 prefix: "gigabitethernet0-"
                 start: 1
                 count: 12
-                pattern: odd
+                pattern: top-odd
             - sequence:
                 kind: interface
                 prefix: "gigabitethernet0-"
                 start: 13
                 count: 12
-                pattern: odd
+                pattern: top-odd
       - spacer: 4
 variants:
   C9300-NM-8X:
@@ -456,19 +457,19 @@ variants:
                 prefix: "gigabitethernet0-"
                 start: 1
                 count: 12
-                pattern: odd
+                pattern: top-odd
             - sequence:
                 kind: interface
                 prefix: "gigabitethernet0-"
                 start: 13
                 count: 12
-                pattern: odd
+                pattern: top-odd
             - sequence:
                 kind: interface
                 prefix: "tengigabitethernet1-"
                 start: 1
                 count: 8
-                pattern: odd
+                pattern: top-odd
 """
 
     def setup_method(self):
@@ -507,7 +508,7 @@ variants:
                 in_areas = True
                 continue
             if in_base and in_areas and s.startswith('"'):
-                cells = s.strip('"').rstrip(';').strip()
+                cells = s.strip('"').rstrip(";").strip()
                 area_rows.append(cells.split())
         assert len(area_rows) == 2
         assert len(area_rows[0]) == 32

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -231,7 +231,9 @@ class TestPrepare:
     @patch("netbox_device_view.utils.ConsolePort")
     @patch("netbox_device_view.utils.DeviceView")
     def test_single_device_returns_dicts(self, MockDV, MockCP):
-        MockDV.objects.get.return_value.grid_template_area = ".area { }"
+        mock_dv = MockDV.objects.get.return_value
+        mock_dv.grid_template_area = ".area { }"
+        mock_dv.has_yaml_layout = False
         MockCP.objects.filter.return_value = []
         dev = self._make_device()
 
@@ -244,7 +246,9 @@ class TestPrepare:
     @patch("netbox_device_view.utils.ConsolePort")
     @patch("netbox_device_view.utils.DeviceView")
     def test_interfaces_processed_into_ports_chassis(self, MockDV, MockCP):
-        MockDV.objects.get.return_value.grid_template_area = ".area { }"
+        mock_dv = MockDV.objects.get.return_value
+        mock_dv.grid_template_area = ".area { }"
+        mock_dv.has_yaml_layout = False
         MockCP.objects.filter.return_value = []
 
         dev = self._make_device()
@@ -263,7 +267,9 @@ class TestPrepare:
     @patch("netbox_device_view.utils.ConsolePort")
     @patch("netbox_device_view.utils.DeviceView")
     def test_virtual_interfaces_excluded(self, MockDV, MockCP):
-        MockDV.objects.get.return_value.grid_template_area = ".area { }"
+        mock_dv = MockDV.objects.get.return_value
+        mock_dv.grid_template_area = ".area { }"
+        mock_dv.has_yaml_layout = False
         MockCP.objects.filter.return_value = []
 
         dev = self._make_device()
@@ -281,7 +287,9 @@ class TestPrepare:
     @patch("netbox_device_view.utils.ConsolePort")
     @patch("netbox_device_view.utils.DeviceView")
     def test_virtual_chassis_scopes_css(self, MockDV, MockCP):
-        MockDV.objects.get.return_value.grid_template_area = ".deviceview.area { }"
+        mock_dv = MockDV.objects.get.return_value
+        mock_dv.grid_template_area = ".deviceview.area { }"
+        mock_dv.has_yaml_layout = False
         MockCP.objects.filter.return_value = []
 
         member1 = MagicMock()


### PR DESCRIPTION
## Summary

- Introduces a YAML-based layout system as a simpler, structured alternative to hand-writing raw CSS `grid-template-areas`
- New CSS Grid renderer powered by YAML layout definitions
- 10 Cisco device YAML examples (C2960X, C9300, FPR1120, and more) to serve as templates
- Full YAML layout schema reference in `docs/yaml-layout-schema.md`
- `css_to_yaml` management command to help migrate existing CSS-based layouts to YAML

## Details

- YAML layouts support `pattern: all`, `pattern: sequence` (with `top-odd`/`top-even`), and explicit port/row definitions
- `row:` field added to sequence schema for multi-row layouts
- Parser, renderer, and 10+ new tests included
- `css_to_yaml` command reads existing DeviceView CSS and outputs an equivalent YAML skeleton

## Notes

> [!IMPORTANT]
> After upgrading, run `python manage.py css_to_yaml` to generate YAML equivalents for your existing CSS layouts. The CSS renderer continues to work unchanged.