### PR TITLE
Add Dockerfile + weekly build workflow for NetBox+plugin image

### DIFF
--- a/.github/workflows/build-netbox-image.yml
+++ b/.github/workflows/build-netbox-image.yml
@@ -5,9 +5,10 @@ on:
     branches: [main]
     paths:
       - "Dockerfile"
-      - "netbox_device_view/**"
+  release:
+    types: [published] # same trigger release.yml uses to publish to PyPI -- rebuild right after a new plugin version actually lands there
   schedule:
-    - cron: "0 2 * * 1" # Monday 02:00 UTC -- catches upstream NetBox stable releases even when nothing here changes
+    - cron: "0 2 * * 1" # Monday 02:00 UTC -- catches upstream NetBox stable releases even when nothing plugin-side changes
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/build-netbox-image.yml
+++ b/.github/workflows/build-netbox-image.yml
@@ -1,0 +1,38 @@
+name: Build NetBox image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - "netbox_device_view/**"
+  schedule:
+    - cron: "0 2 * * 1" # Monday 02:00 UTC -- catches upstream NetBox stable releases even when nothing here changes
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        run: echo "tag=$(date -u +%Y%m%d)-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/peterbaumert/netbox-device-view:latest
+            ghcr.io/peterbaumert/netbox-device-view:${{ steps.meta.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,2 @@
 FROM ghcr.io/netbox-community/netbox:latest
-RUN /opt/netbox/venv/bin/pip install --no-warn-script-location \
-    "git+https://github.com/peterbaumert/netbox-device-view.git@main"
+RUN uv pip install netbox-device-view

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/netbox-community/netbox:latest
+RUN /opt/netbox/venv/bin/pip install --no-warn-script-location \
+    "git+https://github.com/peterbaumert/netbox-device-view.git@main"


### PR DESCRIPTION
## Summary
- Adds a minimal Dockerfile: `FROM ghcr.io/netbox-community/netbox:latest` + pip-install this plugin from `main`
- Adds a build workflow publishing `ghcr.io/peterbaumert/netbox-device-view:latest` (+ a dated/sha tag) on push, weekly schedule (Monday 02:00 UTC), and manual dispatch
- No `configuration.py`/`collectstatic` baked into the image on purpose — `PLUGINS`/`PLUGINS_CONFIG` stay in the deploying Helm chart's values, and the official NetBox image's own entrypoint already runs migrations/collectstatic at startup

## Why
So this repo publishes a ready-to-use "NetBox + this plugin" image that always tracks NetBox's latest *stable* release, for deploying onto a k8s NetBox instance via the official netbox-chart's `image.repository`/`image.tag` override (a custom image is the chart maintainers' explicitly recommended approach for plugin installs — see netbox-chart#173).

## Test plan
- [ ] Confirm the build workflow run succeeds and publishes the image
- [ ] Confirm the GHCR package is public (or set it public manually) so it can be pulled without a registry secret