### PR TITLE
feat: add versioned rendered-layout API endpoint for API clients

### DIFF
--- a/.devcontainer/extra.py
+++ b/.devcontainer/extra.py
@@ -7,3 +7,8 @@ PLUGINS_CONFIG = {
 }
 
 DEVELOPER = True  # allows makemigrations; safe in devcontainer only
+
+# Required since NetBox 4.6 for v2 API tokens; dev-only placeholder value.
+API_TOKEN_PEPPERS = {
+    1: "devcontainer-only-not-a-secret-0123456789abcdef0123456789abcdef"
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: [push, pull_request]
+# See test.yml for why push is restricted to main.
+on:
+  push:
+    branches: [main]
+  pull_request: {}
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: Test
 
-on: [push, pull_request]
+# push is restricted to main (post-merge) rather than every branch — a
+# feature branch with an open PR would otherwise run this workflow twice
+# per commit (once for push, once for pull_request's synchronize event).
+# pull_request has no branch filter, so every PR still gets full coverage.
+on:
+  push:
+    branches: [main]
+  pull_request: {}
 
 jobs:
   test:
@@ -66,6 +73,10 @@ jobs:
           cat > /etc/netbox/config/extra.py << 'EOF'
           PLUGINS = ['netbox_device_view']
           PLUGINS_CONFIG = {'netbox_device_view': {'show_on_device_tab': False}}
+          # v2 API tokens (the non-deprecated format — v1 is deprecated as
+          # of NetBox 4.6, removal planned for v5.0) require this; CI-only
+          # placeholder value, not a real secret.
+          API_TOKEN_PEPPERS = {1: 'ci-test-pepper-not-a-secret-0123456789abcdef0123456789ab'}
           EOF
 
       - name: Install plugin and test dependencies

--- a/docs/rendered-layout-api.md
+++ b/docs/rendered-layout-api.md
@@ -1,0 +1,138 @@
+# Rendered Layout API
+
+A read-only, versioned JSON endpoint that composes a device's SVG layout — structure, port colours, connection state, cable colour, and peer summaries — into a single response. It exists for API clients (e.g. the [netbox-companion](https://github.com/peterbaumert/netbox-companion) mobile app) that render the layout natively instead of embedding NetBox's own HTML/JavaScript device-view page.
+
+The existing [DeviceView CRUD API](configuration.md) (`/api/plugins/device_view/device-view/`) only exposes layout *configuration* (the raw YAML/CSS a device type uses). It does not compose that configuration against a specific device's real interfaces, cables, and connection state — that composition happens in the web UI via [`ports.html`'s inline JavaScript](how-it-works.md). This endpoint moves that composition server-side so API clients don't have to reimplement it.
+
+---
+
+## Endpoint
+
+```
+GET /api/plugins/device_view/devices/<device_id>/rendered-layout/
+```
+
+Token-authenticated, like the rest of the plugin's API. Requires `dcim.view_device` (returns `403` without it) and respects NetBox's normal object-level permission scoping (a device outside the requesting user's permitted scope returns a normal `404`, indistinguishable from a device that doesn't exist — NetBox's API does this everywhere to avoid leaking object existence).
+
+| Condition | Response |
+|---|---|
+| Device does not exist, or exists but is outside the user's object-level permission scope | `404` |
+| User lacks `dcim.view_device` entirely | `403` |
+| Anonymous / unauthenticated | `401`/`403` (per NetBox's `LOGIN_REQUIRED` setting) |
+| Device exists and is visible, but has no `DeviceView` for its device type (or, for a Virtual Chassis, any member's device type) | `200`, `available: false`, `reason: "no_layout"` |
+| A `DeviceView` exists but has no YAML layout (CSS-only/legacy) | `200`, `available: false`, `reason: "svg_layout_required"` |
+| A YAML layout exists but fails to parse | `200`, `available: false`, `reason: "invalid_layout"` (never a traceback) |
+| Everything resolves | `200`, `available: true`, one or more `panels` |
+
+---
+
+## Response schema (`schema_version: 1`)
+
+```json
+{
+  "schema_version": 1,
+  "available": true,
+  "reason": null,
+  "device_id": 123,
+  "render_mode": "svg",
+  "panels": [
+    {
+      "key": "front",
+      "label": "Front",
+      "width": 218,
+      "height": 36,
+      "svg": "<svg xmlns=\"http://www.w3.org/2000/svg\" ...>...</svg>",
+      "hotspots": [
+        {
+          "object_type": "dcim.interface",
+          "object_id": 456,
+          "name": "GigabitEthernet0/1",
+          "x": 6, "y": 6, "width": 24, "height": 24,
+          "enabled": true,
+          "connection_state": "connected",
+          "cable_color": "ff0000",
+          "peer_labels": ["dev1 | GigabitEthernet0/2"],
+          "trace_supported": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Top level
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | int | Always `1` for this version. A future breaking change bumps this rather than mutating the shape in place. |
+| `available` | bool | `false` for any of the reasons above. |
+| `reason` | string \| null | `"no_layout"` \| `"svg_layout_required"` \| `"invalid_layout"` \| `null` (only meaningful when `available` is `false`). |
+| `device_id` | int | Echoes the requested device's primary key. |
+| `render_mode` | string | Always `"svg"` — this endpoint is SVG-only regardless of the DeviceView's own `render_mode` field (see below). |
+| `panels` | array | One entry per rendered face. Empty when `available` is `false`. |
+
+### Panel
+
+| Field | Type | Notes |
+|---|---|---|
+| `key` | string | `"front"` / `"rear"` for a normal device or patch panel. For a Virtual Chassis, `"member-{device_id}-front"` / `"member-{device_id}-rear"` — one set per member. |
+| `label` | string | Human-readable panel label, e.g. `"Front"`, `"Rear (member-2)"`. |
+| `width`, `height` | int | The SVG's pixel dimensions — matches the `viewBox`/`width`/`height` on the embedded `<svg>`. |
+| `svg` | string | Self-contained SVG markup (see [SVG output](#svg-output) below). |
+| `hotspots` | array | One entry per port/interface/console-port element that has a matching real NetBox component. |
+
+### Hotspot
+
+| Field | Type | Notes |
+|---|---|---|
+| `object_type` | string | `"dcim.interface"` \| `"dcim.consoleport"` \| `"dcim.frontport"` \| `"dcim.rearport"` — Django's `app_label.model_name`, so it's safe to route on directly. Power ports are not yet collected by the plugin's layout pipeline (`utils.prepare_svg`), so they never appear here. |
+| `object_id` | int | The real NetBox object's primary key — use this (with `object_type`) to navigate, not a URL. |
+| `name` | string | The component's real name, e.g. `"GigabitEthernet0/1"`. |
+| `x`, `y`, `width`, `height` | int | Hotspot geometry in the same coordinate space as the panel's `svg`/`viewBox` — apply one transform to both. |
+| `enabled` | bool | Always `true` for port-type components (they have no enabled flag); reflects `Interface.enabled` for interfaces. |
+| `connection_state` | string | `"connected"` \| `"partially_connected"` \| `"enabled"` \| `"disabled"`. `"partially_connected"` only applies to interfaces (a cable is attached but the traced path doesn't resolve to a far-end device) — see [SVG Renderer](svg-renderer.md#states). |
+| `cable_color` | string \| null | `null` = no cable attached. `""` = cable attached, no colour set (rendered with a diagonal no-colour pattern). `"rrggbb"` = the cable's configured colour. |
+| `peer_labels` | array of string | `"{device} | {name}"` per resolved peer (traced endpoint for interfaces, direct cable peer for ports). Empty when unconnected. |
+| `trace_supported` | bool | Whether NetBox's REST trace endpoint (`GET /api/dcim/{type}s/{id}/trace/`) exists for this object type. `true` for interfaces and console ports; `false` for front/rear ports, which use `PassThroughPortMixin` and have no `/trace/` action. |
+
+---
+
+## SVG output
+
+Unlike the web UI's SVG (documented in [SVG Renderer](svg-renderer.md)), this endpoint's SVG is built specifically to be safe for renderers with no CSS support and unreliable text layout (e.g. Flutter's `flutter_svg`):
+
+- **No CSS classes.** Every port's fill colour is baked in as an explicit `fill` attribute at composition time — nothing depends on a stylesheet or JavaScript running after the SVG is parsed.
+- **No `<text>` elements.** Port/interface labels are not rendered into the SVG at all — they're returned as `hotspot.name` instead. Renderers that can't reliably centre SVG text (a real, documented `flutter_svg` limitation) render labels as native text overlays positioned from hotspot geometry instead.
+- **No interactivity attributes** (`<title>`, `tabindex`, `role`, `data-bs-*`) — those are a browser/Bootstrap concern with no equivalent here.
+- The same `dv-nocolor-pattern` diagonal-stripe `<defs>` pattern the web renderer uses is included, for cables with no colour set.
+
+If you need to render this SVG in a browser-based tool for debugging, it will look structurally identical to the web UI's SVG but with colours already applied and no labels.
+
+### Why `render_mode` is always `"svg"`
+
+A `DeviceView`'s own `render_mode` field (`css` or `svg`) controls which renderer NetBox's *web* UI uses — it's a per-installation display preference, not a capability flag. This endpoint has no CSS-rendering story at all (there's no equivalent for a mobile client), so it renders SVG whenever a YAML layout exists (`DeviceView.has_yaml_layout`), regardless of what `render_mode` is set to. Only a genuinely CSS-only/legacy DeviceView (no YAML layout at all) returns `svg_layout_required`.
+
+---
+
+## Virtual Chassis
+
+A Virtual Chassis device returns one set of panels per member, in rack order (same ordering the web UI uses), each composed from that member's own device type's `DeviceView`. If **any** member's device type lacks an SVG-capable `DeviceView`, the whole response is `available: false` — there is no partial per-member fallback (this matches the existing `prepare_svg()` behaviour the web UI relies on). See [Virtual Chassis](virtual-chassis.md).
+
+---
+
+## Performance
+
+The composition path (`netbox_device_view.api.rendered_layout`) prefetches cable terminations and cable-trace path objects for every component up front, using the same prefetch shapes NetBox's own `InterfaceViewSet`/`ConsolePortViewSet`/`FrontPortViewSet`/`RearPortViewSet` use (`dcim/api/views.py`) — one request never issues a query per port. This is covered by a regression test (`tests/test_api_rendered_layout.py::QueryCountTests`) that asserts query count doesn't scale with interface count.
+
+No caching (`ETag`/`Last-Modified`) is applied — connection state and cable colour can change at any time, and a stale cached response would show wrong data. This may be revisited if it becomes a real bottleneck.
+
+---
+
+## Compatibility
+
+| Plugin version | Endpoint |
+|---|---|
+| < 0.4.0 | Not present — `GET .../rendered-layout/` 404s (indistinguishable from a missing device at the HTTP level; a client that has independently confirmed the device exists, e.g. via `/api/dcim/devices/<id>/`, can treat a 404 here as "endpoint not supported by this plugin version"). |
+| ≥ 0.4.0 | Present, `schema_version: 1`. |
+
+Clients should treat an unrecognized `schema_version` as unsupported and prompt for a plugin/app update rather than attempting to parse an unknown shape.

--- a/docs/svg-renderer.md
+++ b/docs/svg-renderer.md
@@ -14,7 +14,7 @@ If either condition is not met, the plugin silently falls back to CSS rendering.
 Set **Render Mode → SVG** on the DeviceView edit page. The field is available at *Plugins → Device Views → [edit]*.
 
 !!! note
-    SVG mode is not supported for Virtual Chassis devices — they always use CSS rendering.
+    Virtual Chassis devices render as one SVG panel per member (in rack order), each using that member's own device type's DeviceView — see [Virtual Chassis](virtual-chassis.md). SVG mode requires *every* member's device type to have a YAML-layout DeviceView; if any member is missing one, the whole device falls back to CSS.
 
 ---
 
@@ -127,5 +127,5 @@ Use `cell_size: 0` in the YAML canvas to enable auto sizing for patch panels.
 
 ## Limitations
 
-- Virtual Chassis devices fall back to CSS rendering — SVG mode for VC is not yet supported
+- Virtual Chassis SVG rendering requires every member's device type to have an SVG-capable DeviceView (see above) — one missing member falls the whole device back to CSS
 - `cell_size: 0` (patch-panel auto sizing) uses `DEFAULT_CELL = 32 px` in SVG mode since CSS `auto` sizing has no SVG equivalent

--- a/docs/virtual-chassis.md
+++ b/docs/virtual-chassis.md
@@ -36,6 +36,6 @@ This happens automatically — you do not need to write scoped CSS yourself. The
 
 ## Limitations
 
-- **SVG mode is not supported for Virtual Chassis devices.** They always fall back to CSS rendering regardless of the Render Mode setting.
+- **SVG mode works for Virtual Chassis devices** when every member's device type has an SVG-capable DeviceView (Render Mode → SVG, non-empty YAML Layout) — one panel is rendered per member, in rack order, using that member's own DeviceView.
 - Each VC member must have its own DeviceView configured for its device type.
-- If any member is missing a DeviceView, that member's panel is skipped silently.
+- If **any** member is missing a DeviceView (for either CSS or SVG rendering), the whole device's view fails to render — there is no partial/per-member fallback.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
     - YAML Layout: layout-yaml.md
     - CSS Layout (legacy): layout-css.md
   - SVG Renderer: svg-renderer.md
+  - Rendered Layout API: rendered-layout-api.md
   - Virtual Chassis: virtual-chassis.md
   - Troubleshooting: troubleshooting.md
   - yaml-layout-schema.md

--- a/netbox_device_view/api/rendered_layout.py
+++ b/netbox_device_view/api/rendered_layout.py
@@ -1,0 +1,331 @@
+"""
+Rendered-layout composition for the device rendered-layout API endpoint.
+
+Bridges the layout engine (``netbox_device_view.layout`` — pure, NetBox-
+agnostic geometry) with real NetBox component objects (Interface,
+ConsolePort, FrontPort, RearPort) to produce the versioned JSON envelope
+consumed by API clients (e.g. the netbox-companion mobile app).
+
+This computes connection-state, cable-color, and peer-summary information
+server-side, replicating exactly what ``ports.html``'s inline JavaScript
+(``applyPortStatus()``) currently does client-side for the web tab — see
+that template for the reference behaviour this mirrors. Device/DeviceView
+selection reuses ``utils.py``'s ``_detect_variant``/``_rack_sort_key`` and
+the same stylename derivation as ``process_interfaces``/``process_ports``,
+so layout selection stays identical to the existing web view.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+
+from dcim.models import ConsolePort, Device, FrontPort, Interface, RearPort
+from django.contrib.contenttypes.prefetch import GenericPrefetch
+
+from ..layout import parse as parse_layout
+from ..layout.model import Face, LayoutView
+from ..layout.parser import LayoutParseError
+from ..layout.renderers.svg import render_api_view, svg_dims
+from ..models import DeviceView
+from ..utils import (
+    _derive_interface_stylename,
+    _derive_port_stylename,
+    _detect_variant,
+    _rack_sort_key,
+)
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+# Status colours -- mirror device_view_svg.css's Bootstrap-derived palette.
+# Baked in as explicit SVG fill attributes since flutter_svg (the
+# netbox-companion mobile client's renderer) cannot resolve the CSS classes
+# the web renderer relies on for the same states.
+COLOUR_CONNECTED = "#198754"  # bg-success
+COLOUR_ENABLED = "#6c757d"  # bg-secondary (enabled, not connected)
+COLOUR_DISABLED = "#dc3545"  # bg-danger
+COLOUR_PARTIAL = "#ffc107"  # bg-warning
+NO_COLOR_FILL = "url(#dv-nocolor-pattern)"
+
+_HEX_COLOR_RE = re.compile(r"^[0-9A-Fa-f]{6}$")
+
+# Component types with a NetBox REST /trace/ action (PathEndpointMixin in
+# dcim/api/views.py). FrontPort/RearPort use PassThroughPortMixin instead
+# and have no /trace/ action.
+_TRACE_SUPPORTED_MODELS = {"interface", "consoleport"}
+
+
+class UnavailableReason:
+    NO_LAYOUT = "no_layout"
+    SVG_LAYOUT_REQUIRED = "svg_layout_required"
+    INVALID_LAYOUT = "invalid_layout"
+
+
+@dataclass
+class ComponentStatus:
+    component: object
+    object_type: str
+    enabled: bool
+    connection_state: (
+        str  # "connected" | "partially_connected" | "enabled" | "disabled"
+    )
+    cable_color: str | None  # None = no cable, "" = cable with no color set
+    peer_labels: list[str] = field(default_factory=list)
+
+
+def _peer_label(peer) -> str:
+    device = getattr(peer, "device", None)
+    name = getattr(peer, "name", None)
+    if device and name:
+        return f"{device} | {name}"
+    return str(peer)
+
+
+def compute_component_status(component, *, is_port: bool) -> ComponentStatus:
+    """Replicate ports.html's applyPortStatus() JS, in Python, for one component."""
+    object_type = f"dcim.{type(component)._meta.model_name}"
+
+    if is_port:
+        enabled = True
+        link_peers = list(component.link_peers)
+        connected = bool(link_peers)
+        partially_connected = False
+        peers = link_peers
+    else:
+        enabled = bool(component.enabled)
+        connected_endpoints = list(component.connected_endpoints or [])
+        link_peers = list(component.link_peers)
+        connected = bool(connected_endpoints)
+        partially_connected = bool(link_peers) and not connected
+        peers = connected_endpoints or link_peers
+
+    if connected:
+        state = "connected"
+    elif partially_connected:
+        state = "partially_connected"
+    elif enabled:
+        state = "enabled"
+    else:
+        state = "disabled"
+
+    cable = getattr(component, "cable", None)
+    cable_color = cable.color if cable else None
+
+    return ComponentStatus(
+        component=component,
+        object_type=object_type,
+        enabled=enabled,
+        connection_state=state,
+        cable_color=cable_color,
+        peer_labels=[_peer_label(p) for p in peers],
+    )
+
+
+def _fill_for(status: ComponentStatus) -> str:
+    if status.cable_color is not None:
+        if status.cable_color == "":
+            return NO_COLOR_FILL
+        if _HEX_COLOR_RE.match(status.cable_color):
+            return f"#{status.cable_color}"
+        # Malformed value somehow stored on the model — don't trust it raw
+        # in hand-built SVG; fall through to the state colour instead.
+        logger.warning(
+            "Ignoring non-hex cable color %r on %s",
+            status.cable_color,
+            status.component,
+        )
+
+    return {
+        "connected": COLOUR_CONNECTED,
+        "partially_connected": COLOUR_PARTIAL,
+        "enabled": COLOUR_ENABLED,
+        "disabled": COLOUR_DISABLED,
+    }[status.connection_state]
+
+
+def _component_querysets(device):
+    """Return (interfaces, console_ports, front_ports, rear_ports) querysets
+    for one device, with N+1-avoiding prefetches matching the same
+    prefetch shape NetBox's own InterfaceViewSet/ConsolePortViewSet/
+    FrontPortViewSet/RearPortViewSet use (dcim/api/views.py)."""
+    interfaces = (
+        Interface.objects.filter(device=device)
+        .exclude(type__in=("virtual", "lag"))
+        .prefetch_related(
+            GenericPrefetch(
+                "cable__terminations__termination",
+                [Interface.objects.select_related("device", "cable")],
+            ),
+            GenericPrefetch(
+                "_path__path_objects",
+                [Interface.objects.select_related("device", "cable")],
+            ),
+        )
+    )
+    console_ports = ConsolePort.objects.filter(device=device).prefetch_related(
+        "_path", "cable__terminations"
+    )
+    front_ports = (
+        FrontPort.objects.filter(device=device)
+        .exclude(type="virtual")
+        .prefetch_related("cable__terminations")
+    )
+    rear_ports = (
+        RearPort.objects.filter(device=device)
+        .exclude(type="virtual")
+        .prefetch_related("cable__terminations")
+    )
+    return interfaces, console_ports, front_ports, rear_ports
+
+
+def _stylename_map(device) -> dict[str, ComponentStatus]:
+    """Return {stylename: ComponentStatus} for every eligible component on
+    one device — the same key space PlacedElement.key ("stylename") uses."""
+    interfaces, console_ports, front_ports, rear_ports = _component_querysets(device)
+
+    by_stylename: dict[str, ComponentStatus] = {}
+    for itf in interfaces:
+        by_stylename[_derive_interface_stylename(itf.name)] = compute_component_status(
+            itf, is_port=False
+        )
+    for port in list(console_ports) + list(front_ports) + list(rear_ports):
+        by_stylename[_derive_port_stylename(port.name)] = compute_component_status(
+            port, is_port=True
+        )
+    return by_stylename
+
+
+def _unavailable(device_id: int, reason: str) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "available": False,
+        "reason": reason,
+        "device_id": device_id,
+        "render_mode": "svg",
+        "panels": [],
+    }
+
+
+def compose_rendered_layout(device: Device) -> dict:
+    """
+    Compose the full rendered-layout JSON envelope for one device.
+
+    Handles both plain devices and virtual chassis (one set of panels per
+    member, in rack order) — mirrors utils.prepare_svg()'s branching.
+    Returns a plain dict matching the API's documented schema; never
+    raises for expected "no layout"/"invalid layout" conditions (those are
+    reported via ``available``/``reason`` instead).
+    """
+    if device.virtual_chassis is None:
+        members = [device]
+    else:
+        members = sorted(
+            device.virtual_chassis.members.select_related("rack").all(),
+            key=_rack_sort_key,
+        )
+
+    # First pass: resolve every member's DeviceView. Any missing/CSS-only
+    # DeviceView fails the whole response (matches prepare_svg()'s
+    # all-or-nothing ObjectDoesNotExist behaviour for virtual chassis).
+    member_views: dict[int, DeviceView] = {}
+    for member in members:
+        try:
+            member_views[member.pk] = DeviceView.objects.get(
+                device_type=member.device_type
+            )
+        except DeviceView.DoesNotExist:
+            return _unavailable(device.pk, UnavailableReason.NO_LAYOUT)
+
+    for member in members:
+        if not member_views[member.pk].has_yaml_layout:
+            return _unavailable(device.pk, UnavailableReason.SVG_LAYOUT_REQUIRED)
+
+    panels = []
+    try:
+        for member in members:
+            device_view = member_views[member.pk]
+            normalized = parse_layout(device_view.yaml_layout)
+            member_modules = list(member.modules.all())
+            variant = _detect_variant(member_modules, device_view)
+            status_by_stylename = _stylename_map(member)
+
+            member_prefix = f"member-{member.pk}-" if len(members) > 1 else ""
+            member_suffix = f" ({member.name})" if len(members) > 1 else ""
+
+            face_views: list[tuple[str, str, LayoutView]] = []
+            if normalized.has_separate_faces():
+                if normalized.front:
+                    face_views.append(("front", "Front", normalized.front))
+                if normalized.rear:
+                    face_views.append(("rear", "Rear", normalized.rear))
+            else:
+                view = normalized.front or normalized.rear
+                if view is not None:
+                    face_label = "Rear" if view.face == Face.REAR else "Front"
+                    face_key = "rear" if view.face == Face.REAR else "front"
+                    face_views.append((face_key, face_label, view))
+
+            for face_key, face_label, view in face_views:
+                svg, geometry = render_api_view(
+                    view,
+                    fills={k: _fill_for(v) for k, v in status_by_stylename.items()},
+                    variant_name=variant,
+                )
+                hotspots = []
+                for cell in geometry:
+                    status = status_by_stylename.get(cell["key"])
+                    if status is None:
+                        continue
+                    component = status.component
+                    hotspots.append(
+                        {
+                            "object_type": status.object_type,
+                            "object_id": component.pk,
+                            "name": component.name,
+                            "x": cell["x"],
+                            "y": cell["y"],
+                            "width": cell["width"],
+                            "height": cell["height"],
+                            "enabled": status.enabled,
+                            "connection_state": status.connection_state,
+                            "cable_color": status.cable_color,
+                            "peer_labels": status.peer_labels,
+                            "trace_supported": type(component)._meta.model_name
+                            in _TRACE_SUPPORTED_MODELS,
+                        }
+                    )
+                width, height = svg_dims(view.canvas)
+                panels.append(
+                    {
+                        "key": f"{member_prefix}{face_key}",
+                        "label": f"{face_label}{member_suffix}",
+                        "width": width,
+                        "height": height,
+                        "svg": svg,
+                        "hotspots": hotspots,
+                    }
+                )
+    except LayoutParseError:
+        logger.warning(
+            "Invalid YAML layout for device %s (device_type %s)",
+            device.pk,
+            device.device_type_id,
+        )
+        return _unavailable(device.pk, UnavailableReason.INVALID_LAYOUT)
+    except Exception:
+        logger.exception(
+            "Unexpected error composing rendered layout for device %s", device.pk
+        )
+        return _unavailable(device.pk, UnavailableReason.INVALID_LAYOUT)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "available": True,
+        "reason": None,
+        "device_id": device.pk,
+        "render_mode": "svg",
+        "panels": panels,
+    }

--- a/netbox_device_view/api/urls.py
+++ b/netbox_device_view/api/urls.py
@@ -1,3 +1,4 @@
+from django.urls import path
 from netbox.api.routers import NetBoxRouter
 
 from . import views
@@ -7,4 +8,10 @@ app_name = "netbox_device_view"
 router = NetBoxRouter()
 router.register("device-view", views.DeviceViewViewSet)
 
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path(
+        "devices/<int:pk>/rendered-layout/",
+        views.DeviceRenderedLayoutView.as_view(),
+        name="device_rendered_layout",
+    ),
+]

--- a/netbox_device_view/api/views.py
+++ b/netbox_device_view/api/views.py
@@ -1,9 +1,48 @@
+from dcim.models import Device
 from netbox.api.viewsets import NetBoxModelViewSet
+from rest_framework.generics import RetrieveAPIView
+from rest_framework.response import Response
 
 from .. import models
+from .rendered_layout import compose_rendered_layout
 from .serializers import DeviceViewSerializer
 
 
 class DeviceViewViewSet(NetBoxModelViewSet):
     queryset = models.DeviceView.objects.prefetch_related("tags")
     serializer_class = DeviceViewSerializer
+
+
+class DeviceRenderedLayoutView(RetrieveAPIView):
+    """
+    GET /api/plugins/device_view/devices/<pk>/rendered-layout/
+
+    Read-only, versioned JSON composition of a device's rendered layout —
+    SVG structure plus hotspot geometry and connection state, keyed by
+    NetBox object — for API clients that can't (or shouldn't) reimplement
+    this plugin's YAML/SVG rendering pipeline. See
+    netbox_device_view.api.rendered_layout for the composition logic and
+    docs/rendered-layout-api.md for the response schema.
+
+    Uses the same permission/authentication stack as the rest of the
+    plugin's API (DRF's default TokenPermissions, configured globally by
+    NetBox): a 403 for users without ``dcim.view_device`` at all, a normal
+    404 for a device that doesn't exist *or* is outside the requesting
+    user's object-level permission scope (``get_queryset`` applies
+    ``.restrict()`` — the same object-level filtering NetBoxModelViewSet
+    uses — so an out-of-scope device is indistinguishable from a missing
+    one, matching NetBox's own API behaviour elsewhere).
+
+    No serializer_class: the response is a composed dict, not a model
+    representation, so it's returned directly rather than forced through
+    ModelSerializer machinery that doesn't fit its shape.
+    """
+
+    queryset = Device.objects.all()
+
+    def get_queryset(self):
+        return super().get_queryset().restrict(self.request.user, "view")
+
+    def get(self, request, *args, **kwargs):
+        device = self.get_object()
+        return Response(compose_rendered_layout(device))

--- a/netbox_device_view/layout/renderers/svg.py
+++ b/netbox_device_view/layout/renderers/svg.py
@@ -141,6 +141,89 @@ def render(layout: NormalizedLayout, variant_name: str | None = None) -> str:
     return "\n".join(parts)
 
 
+def render_api_view(
+    view: LayoutView,
+    fills: dict[str, str] | None = None,
+    variant_name: str | None = None,
+) -> tuple[str, list[dict]]:
+    """
+    Render a single LayoutView to a flutter_svg-safe SVG string, alongside
+    hotspot geometry for every port-like element.
+
+    Used by the rendered-layout API endpoint (netbox_device_view.api.
+    rendered_layout), not the web UI. Unlike ``_render_view``:
+
+    - Every port's fill colour is baked in as an explicit ``fill``
+      attribute from ``fills`` (falling back to COLOUR_PORT_DEFAULT when a
+      key is absent), since API clients (e.g. the netbox-companion mobile
+      app's flutter_svg renderer) cannot resolve CSS class selectors the
+      way a browser can.
+    - No ``<text>`` is emitted. flutter_svg's ``dominant-baseline``/``dy``
+      support is unreliable for real vertical centring (see
+      netbox-companion's rack_elevation_svg.dart, which works around the
+      same limitation for NetBox's own rack elevation SVGs). Labels are
+      returned as hotspot geometry instead so the API client can render
+      them as native text overlays.
+    - No interactivity attributes (title/tabindex/role/data-bs-*) — those
+      are a browser/Bootstrap concern with no API client equivalent.
+
+    Returns ``(svg_markup, hotspots)`` where each hotspot is
+    ``{"key": stylename, "x": int, "y": int, "width": int, "height": int}``
+    for every element where ``PlacedElement.is_port`` is True (ports,
+    interfaces, console ports — matches the real component set this
+    plugin currently collects; see utils.prepare_svg). Spacer/blank/label
+    elements are skipped entirely — no fill, no hotspot. The caller merges
+    these with real NetBox component data (name, object type/id,
+    connection state, cable color, peers, ...) keyed by the same
+    stylename.
+    """
+    fills = fills or {}
+    canvas = view.canvas
+    width, height = svg_dims(canvas)
+    bg = canvas.background or COLOUR_BACKGROUND
+
+    lines: list[str] = [
+        (
+            f'<svg xmlns="http://www.w3.org/2000/svg"'
+            f' width="{width}" height="{height}"'
+            f' viewBox="0 0 {width} {height}" role="img">'
+        ),
+        "  <defs>",
+        (
+            '    <pattern id="dv-nocolor-pattern" patternUnits="userSpaceOnUse"'
+            ' width="10" height="10" patternTransform="rotate(-45)">'
+        ),
+        '      <rect width="5" height="10" fill="grey"/>',
+        '      <rect x="5" width="5" height="10" fill="black"/>',
+        "    </pattern>",
+        "  </defs>",
+        (
+            f'  <rect x="0" y="0" width="{width}" height="{height}"'
+            f' rx="5" ry="5" fill="{html.escape(bg)}" stroke="#999" stroke-width="1"/>'
+        ),
+    ]
+
+    hotspots: list[dict] = []
+    elements = view.elements_for_variant(variant_name)
+    for el in sorted(elements, key=lambda e: (e.row, e.col)):
+        if not el.is_port:
+            continue  # spacer / blank / label — structural or decorative only
+
+        x, y = cell_xy(el.row, el.col, canvas)
+        w, h = element_dims(el, canvas)
+        fill = html.escape(fills.get(el.key, COLOUR_PORT_DEFAULT), quote=True)
+
+        lines.append(
+            f'  <rect x="{x}" y="{y}" width="{w}" height="{h}"'
+            f' rx="{CORNER_RADIUS}" ry="{CORNER_RADIUS}"'
+            f' fill="{fill}" stroke="{COLOUR_BORDER}" stroke-width="1"/>'
+        )
+        hotspots.append({"key": el.key, "x": x, "y": y, "width": w, "height": h})
+
+    lines.append("</svg>")
+    return "\n".join(lines), hotspots
+
+
 def render_view_svg(
     layout: NormalizedLayout,
     face: str = "front",
@@ -172,30 +255,30 @@ def render_view_svg(
 # ── Coordinate helpers ─────────────────────────────────────────────────────────
 
 
-def _cell_size(canvas: CanvasConfig) -> int:
+def cell_size(canvas: CanvasConfig) -> int:
     """Return effective cell size, replacing the patch-panel sentinel (0) with DEFAULT_CELL."""
     return canvas.cell_size if canvas.cell_size > 0 else DEFAULT_CELL
 
 
-def _svg_dims(canvas: CanvasConfig) -> tuple[int, int]:
+def svg_dims(canvas: CanvasConfig) -> tuple[int, int]:
     """Return (total_width, total_height) for the SVG viewport."""
-    cs = _cell_size(canvas)
+    cs = cell_size(canvas)
     w = canvas.columns * cs + max(0, canvas.columns - 1) * GAP + 2 * PADDING
     h = canvas.rows * cs + max(0, canvas.rows - 1) * GAP + 2 * PADDING
     return w, h
 
 
-def _cell_xy(row: int, col: int, canvas: CanvasConfig) -> tuple[int, int]:
+def cell_xy(row: int, col: int, canvas: CanvasConfig) -> tuple[int, int]:
     """Convert 1-based (row, col) grid coords to SVG pixel coords (top-left of cell)."""
-    cs = _cell_size(canvas)
+    cs = cell_size(canvas)
     x = PADDING + (col - 1) * (cs + GAP)
     y = PADDING + (row - 1) * (cs + GAP)
     return x, y
 
 
-def _element_dims(el: PlacedElement, canvas: CanvasConfig) -> tuple[int, int]:
+def element_dims(el: PlacedElement, canvas: CanvasConfig) -> tuple[int, int]:
     """Return (width, height) in pixels for an element, including its span."""
-    cs = _cell_size(canvas)
+    cs = cell_size(canvas)
     w = el.col_span * cs + max(0, el.col_span - 1) * GAP
     h = el.row_span * cs + max(0, el.row_span - 1) * GAP
     return w, h
@@ -211,7 +294,7 @@ def _render_view(
 ) -> str:
     """Render a single LayoutView to an ``<svg>`` element string."""
     canvas = view.canvas
-    width, height = _svg_dims(canvas)
+    width, height = svg_dims(canvas)
     bg = canvas.background or COLOUR_BACKGROUND
 
     face_attr = f' data-face="{data_face}"' if data_face else ""
@@ -268,9 +351,9 @@ def _render_element(
     el: PlacedElement, canvas: CanvasConfig, pad: str = "  "
 ) -> list[str]:
     """Render a single PlacedElement to SVG lines."""
-    x, y = _cell_xy(el.row, el.col, canvas)
-    w, h = _element_dims(el, canvas)
-    cs = _cell_size(canvas)
+    x, y = cell_xy(el.row, el.col, canvas)
+    w, h = element_dims(el, canvas)
+    cs = cell_size(canvas)
 
     if el.kind == ElementKind.LABEL:
         return _render_label_element(el, x, y, w, h, pad)

--- a/tests/test_api_rendered_layout.py
+++ b/tests/test_api_rendered_layout.py
@@ -8,8 +8,6 @@ system, cable/interface relationships, and Django URL routing — none of
 which can be exercised with SimpleNamespace mocks.
 """
 
-import secrets
-
 from core.models import ObjectType
 from dcim.models import (
     Cable,
@@ -30,7 +28,7 @@ from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
-from users.choices import TokenVersionChoices
+from users.constants import TOKEN_PREFIX
 from users.models import ObjectPermission, Token, User
 
 from netbox_device_view.models import DeviceView, RenderMode
@@ -111,15 +109,16 @@ class RenderedLayoutTestBase(TestCase):
         perm.object_types.add(object_type)
 
     def _authenticate(self):
-        # Explicit v1 token: the default (v2, peppered/digest) format
-        # requires API_TOKEN_PEPPERS to be configured, which neither this
-        # repo's CI workflow (test.yml) nor a bare devcontainer sets up —
-        # v1 tokens need no such server-side config and authenticate with
-        # the classic `Authorization: Token <key>` header.
-        plaintext = secrets.token_hex(20)
-        token = Token(user=self.user, version=TokenVersionChoices.V1, token=plaintext)
-        token.save()
-        self.client.credentials(HTTP_AUTHORIZATION=f"Token {plaintext}")
+        # v2 (the non-deprecated token format — v1 is deprecated as of
+        # NetBox 4.6, removal planned for v5.0) needs API_TOKEN_PEPPERS
+        # configured server-side; both this repo's devcontainer
+        # (.devcontainer/extra.py) and CI (test.yml) set a placeholder
+        # value for it. Matches NetBox's own
+        # utilities.testing.api.APITestCase.setUp() convention.
+        token = Token.objects.create(user=self.user)
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {TOKEN_PREFIX}{token.key}.{token.token}"
+        )
 
     def _url(self, device=None):
         return reverse(

--- a/tests/test_api_rendered_layout.py
+++ b/tests/test_api_rendered_layout.py
@@ -8,6 +8,8 @@ system, cable/interface relationships, and Django URL routing — none of
 which can be exercised with SimpleNamespace mocks.
 """
 
+import secrets
+
 from core.models import ObjectType
 from dcim.models import (
     Cable,
@@ -28,7 +30,7 @@ from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
-from users.constants import TOKEN_PREFIX
+from users.choices import TokenVersionChoices
 from users.models import ObjectPermission, Token, User
 
 from netbox_device_view.models import DeviceView, RenderMode
@@ -109,15 +111,15 @@ class RenderedLayoutTestBase(TestCase):
         perm.object_types.add(object_type)
 
     def _authenticate(self):
-        # NetBox 4.6+ tokens default to v2 (peppered/digest) format, where
-        # `.key` alone is only a short public identifier, not the bearer
-        # secret — `Authorization: Token <key>` (v1 scheme) silently fails
-        # auth for a v2 token. Use the real v2 Bearer scheme, matching
-        # NetBox's own utilities.testing.api.APITestCase.setUp().
-        token = Token.objects.create(user=self.user)
-        self.client.credentials(
-            HTTP_AUTHORIZATION=f"Bearer {TOKEN_PREFIX}{token.key}.{token.token}"
-        )
+        # Explicit v1 token: the default (v2, peppered/digest) format
+        # requires API_TOKEN_PEPPERS to be configured, which neither this
+        # repo's CI workflow (test.yml) nor a bare devcontainer sets up —
+        # v1 tokens need no such server-side config and authenticate with
+        # the classic `Authorization: Token <key>` header.
+        plaintext = secrets.token_hex(20)
+        token = Token(user=self.user, version=TokenVersionChoices.V1, token=plaintext)
+        token.save()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {plaintext}")
 
     def _url(self, device=None):
         return reverse(

--- a/tests/test_api_rendered_layout.py
+++ b/tests/test_api_rendered_layout.py
@@ -1,0 +1,552 @@
+"""
+Tests for the device rendered-layout API endpoint
+(GET /api/plugins/device_view/devices/<pk>/rendered-layout/).
+
+Uses real DB-backed fixtures (unlike test_utils.py's mock-based unit tests)
+since this endpoint's behaviour is defined by NetBox's own permission
+system, cable/interface relationships, and Django URL routing — none of
+which can be exercised with SimpleNamespace mocks.
+"""
+
+from core.models import ObjectType
+from dcim.models import (
+    Cable,
+    ConsolePort,
+    Device,
+    DeviceRole,
+    DeviceType,
+    FrontPort,
+    Interface,
+    Manufacturer,
+    RearPort,
+    Site,
+    VirtualChassis,
+)
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+from users.constants import TOKEN_PREFIX
+from users.models import ObjectPermission, Token, User
+
+from netbox_device_view.models import DeviceView, RenderMode
+
+SVG_YAML = """
+version: 1
+canvas:
+  columns: 8
+  rows: 1
+  cell_size: 24
+views:
+  front:
+    rows:
+      - sequence:
+          kind: interface
+          prefix: "gigabitethernet-"
+          start: 1
+          count: 4
+          pattern: all
+"""
+
+PATCH_PANEL_YAML = """
+version: 1
+canvas:
+  columns: 4
+  rows: 1
+  cell_size: 24
+views:
+  front:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "port-"
+          start: 1
+          count: 2
+          pattern: all
+  rear:
+    rows:
+      - sequence:
+          kind: port
+          prefix: "port-"
+          start: 1
+          count: 2
+          pattern: all
+"""
+
+INVALID_YAML = "version: 1\nviews: [this is not closed"
+
+
+class RenderedLayoutTestBase(TestCase):
+    def setUp(self):
+        self.manufacturer = Manufacturer.objects.create(name="Mfr", slug="mfr")
+        self.device_type = DeviceType.objects.create(
+            manufacturer=self.manufacturer,
+            model="Switch4",
+            slug="switch4",
+            u_height=1,
+        )
+        self.role = DeviceRole.objects.create(name="Role", slug="role")
+        self.site = Site.objects.create(name="Site", slug="site")
+        self.device = Device.objects.create(
+            name="dev1",
+            device_type=self.device_type,
+            role=self.role,
+            site=self.site,
+            status="active",
+        )
+        self.user = User.objects.create_user(username="tester")
+        self.client = APIClient()
+
+    def _grant(self, name, constraints=None):
+        app_label, action_model = name.split(".")
+        action, model = action_model.split("_", 1)
+        object_type = ObjectType.objects.get_by_natural_key(app_label, model)
+        perm = ObjectPermission(name=name, actions=[action], constraints=constraints)
+        perm.save()
+        perm.users.add(self.user)
+        perm.object_types.add(object_type)
+
+    def _authenticate(self):
+        # NetBox 4.6+ tokens default to v2 (peppered/digest) format, where
+        # `.key` alone is only a short public identifier, not the bearer
+        # secret — `Authorization: Token <key>` (v1 scheme) silently fails
+        # auth for a v2 token. Use the real v2 Bearer scheme, matching
+        # NetBox's own utilities.testing.api.APITestCase.setUp().
+        token = Token.objects.create(user=self.user)
+        self.client.credentials(
+            HTTP_AUTHORIZATION=f"Bearer {TOKEN_PREFIX}{token.key}.{token.token}"
+        )
+
+    def _url(self, device=None):
+        return reverse(
+            "plugins-api:netbox_device_view-api:device_rendered_layout",
+            kwargs={"pk": (device or self.device).pk},
+        )
+
+    def _make_interfaces(self, count=4, device=None):
+        device = device or self.device
+        return [
+            Interface.objects.create(
+                device=device,
+                name=f"GigabitEthernet0/{n}",
+                type="1000base-t",
+                enabled=True,
+            )
+            for n in range(1, count + 1)
+        ]
+
+
+class AuthenticationTests(RenderedLayoutTestBase):
+    def test_anonymous_request_is_rejected(self):
+        response = self.client.get(self._url())
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
+
+    def test_authenticated_without_permission_is_403(self):
+        self._authenticate()
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_authenticated_with_permission_succeeds(self):
+        self._authenticate()
+        self._grant("dcim.view_device")
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class ObjectPermissionTests(RenderedLayoutTestBase):
+    def test_device_outside_permission_scope_is_404_not_403(self):
+        other_site = Site.objects.create(name="Other Site", slug="other-site")
+        other_device = Device.objects.create(
+            name="dev2",
+            device_type=self.device_type,
+            role=self.role,
+            site=other_site,
+            status="active",
+        )
+        self._authenticate()
+        self._grant("dcim.view_device", constraints={"site__slug": self.site.slug})
+
+        in_scope = self.client.get(self._url(self.device))
+        self.assertEqual(in_scope.status_code, status.HTTP_200_OK)
+
+        out_of_scope = self.client.get(self._url(other_device))
+        self.assertEqual(out_of_scope.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_missing_device_is_404(self):
+        self._authenticate()
+        self._grant("dcim.view_device")
+        response = self.client.get(self._url(device=type("D", (), {"pk": 999999})()))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class AvailabilityTests(RenderedLayoutTestBase):
+    def setUp(self):
+        super().setUp()
+        self._authenticate()
+        self._grant("dcim.view_device")
+
+    def test_no_device_view_configured(self):
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["available"])
+        self.assertEqual(data["reason"], "no_layout")
+        self.assertEqual(data["panels"], [])
+        self.assertEqual(data["schema_version"], 1)
+        self.assertEqual(data["device_id"], self.device.pk)
+
+    def test_css_only_layout_requires_svg(self):
+        DeviceView.objects.create(
+            device_type=self.device_type,
+            grid_template_area="some legacy css",
+            yaml_layout="",
+            render_mode=RenderMode.CSS,
+        )
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["available"])
+        self.assertEqual(data["reason"], "svg_layout_required")
+
+    def test_yaml_layout_renders_regardless_of_web_render_mode_preference(self):
+        # The mobile API always wants SVG; a YAML layout with render_mode
+        # left at the CSS default (a plausible admin default/oversight)
+        # should still produce SVG here — only has_yaml_layout gates this.
+        DeviceView.objects.create(
+            device_type=self.device_type,
+            grid_template_area="",
+            yaml_layout=SVG_YAML,
+            render_mode=RenderMode.CSS,
+        )
+        self._make_interfaces()
+        response = self.client.get(self._url())
+        data = response.json()
+        self.assertTrue(data["available"])
+
+    def test_invalid_yaml_reports_safe_reason_not_traceback(self):
+        DeviceView.objects.create(
+            device_type=self.device_type,
+            grid_template_area="",
+            yaml_layout=INVALID_YAML,
+            render_mode=RenderMode.SVG,
+        )
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertFalse(data["available"])
+        self.assertEqual(data["reason"], "invalid_layout")
+        body_text = response.content.decode()
+        self.assertNotIn("Traceback", body_text)
+        self.assertNotIn(".py", body_text)
+
+
+class RenderedPanelTests(RenderedLayoutTestBase):
+    def setUp(self):
+        super().setUp()
+        self._authenticate()
+        self._grant("dcim.view_device")
+        self.device_view = DeviceView.objects.create(
+            device_type=self.device_type,
+            grid_template_area="",
+            yaml_layout=SVG_YAML,
+            render_mode=RenderMode.SVG,
+        )
+
+    def test_schema_shape(self):
+        self._make_interfaces()
+        response = self.client.get(self._url())
+        data = response.json()
+        self.assertEqual(
+            set(data.keys()),
+            {
+                "schema_version",
+                "available",
+                "reason",
+                "device_id",
+                "render_mode",
+                "panels",
+            },
+        )
+        self.assertEqual(len(data["panels"]), 1)
+        panel = data["panels"][0]
+        self.assertEqual(
+            set(panel.keys()), {"key", "label", "width", "height", "svg", "hotspots"}
+        )
+        self.assertGreater(panel["width"], 0)
+        self.assertGreater(panel["height"], 0)
+        self.assertIn("<svg", panel["svg"])
+
+    def test_hotspot_shape_and_no_svg_text_elements(self):
+        self._make_interfaces()
+        response = self.client.get(self._url())
+        panel = response.json()["panels"][0]
+        self.assertEqual(len(panel["hotspots"]), 4)
+        hotspot = panel["hotspots"][0]
+        self.assertEqual(
+            set(hotspot.keys()),
+            {
+                "object_type",
+                "object_id",
+                "name",
+                "x",
+                "y",
+                "width",
+                "height",
+                "enabled",
+                "connection_state",
+                "cable_color",
+                "peer_labels",
+                "trace_supported",
+            },
+        )
+        # flutter_svg can't reliably centre <text> — labels travel as
+        # hotspot.name instead; the SVG itself must carry none.
+        self.assertNotIn("<text", panel["svg"])
+        self.assertNotIn("class=", panel["svg"])
+        self.assertNotIn("dominant-baseline", panel["svg"])
+
+    def test_disabled_interface_is_disabled_state_with_no_cable(self):
+        ifaces = self._make_interfaces()
+        ifaces[0].enabled = False
+        ifaces[0].save(update_fields=["enabled"])
+
+        response = self.client.get(self._url())
+        hotspots = {h["name"]: h for h in response.json()["panels"][0]["hotspots"]}
+        h = hotspots["GigabitEthernet0/1"]
+        self.assertFalse(h["enabled"])
+        self.assertEqual(h["connection_state"], "disabled")
+        self.assertIsNone(h["cable_color"])
+        self.assertEqual(h["peer_labels"], [])
+        self.assertTrue(h["trace_supported"])
+
+    def test_enabled_unconnected_interface(self):
+        self._make_interfaces()
+        response = self.client.get(self._url())
+        hotspots = {h["name"]: h for h in response.json()["panels"][0]["hotspots"]}
+        h = hotspots["GigabitEthernet0/1"]
+        self.assertTrue(h["enabled"])
+        self.assertEqual(h["connection_state"], "enabled")
+        self.assertIsNone(h["cable_color"])
+
+    def test_connected_interface_with_cable_color(self):
+        ifaces = self._make_interfaces()
+        Cable(
+            a_terminations=[ifaces[0]], b_terminations=[ifaces[1]], color="ff0000"
+        ).save()
+
+        response = self.client.get(self._url())
+        hotspots = {h["name"]: h for h in response.json()["panels"][0]["hotspots"]}
+
+        h1 = hotspots["GigabitEthernet0/1"]
+        self.assertEqual(h1["connection_state"], "connected")
+        self.assertEqual(h1["cable_color"], "ff0000")
+        self.assertEqual(h1["peer_labels"], ["dev1 | GigabitEthernet0/2"])
+
+        h2 = hotspots["GigabitEthernet0/2"]
+        self.assertEqual(h2["connection_state"], "connected")
+        self.assertEqual(h2["peer_labels"], ["dev1 | GigabitEthernet0/1"])
+
+    def test_connected_interface_with_no_cable_color_set(self):
+        ifaces = self._make_interfaces()
+        Cable(a_terminations=[ifaces[0]], b_terminations=[ifaces[1]], color="").save()
+
+        response = self.client.get(self._url())
+        hotspots = {h["name"]: h for h in response.json()["panels"][0]["hotspots"]}
+        h1 = hotspots["GigabitEthernet0/1"]
+        self.assertEqual(h1["cable_color"], "")
+        self.assertEqual(h1["connection_state"], "connected")
+
+    def test_console_port_hotspot_has_no_trace_support_false_for_front_rear(self):
+        # Front/rear ports use PassThroughPortMixin (no /trace/ action);
+        # console ports and interfaces use PathEndpointMixin (have one).
+        DeviceView.objects.filter(pk=self.device_view.pk).update(yaml_layout="""
+version: 1
+canvas:
+  columns: 4
+  rows: 1
+  cell_size: 24
+views:
+  front:
+    rows:
+      - sequence:
+          kind: console-port
+          prefix: "console-"
+          start: 1
+          count: 1
+          pattern: all
+""")
+        ConsolePort.objects.create(device=self.device, name="Console 1", type="rj-45")
+        response = self.client.get(self._url())
+        hotspots = response.json()["panels"][0]["hotspots"]
+        self.assertEqual(len(hotspots), 1)
+        self.assertEqual(hotspots[0]["object_type"], "dcim.consoleport")
+        self.assertTrue(hotspots[0]["trace_supported"])
+
+
+class PatchPanelMultiPanelTests(RenderedLayoutTestBase):
+    def setUp(self):
+        super().setUp()
+        self._authenticate()
+        self._grant("dcim.view_device")
+        DeviceView.objects.create(
+            device_type=self.device_type,
+            grid_template_area="",
+            yaml_layout=PATCH_PANEL_YAML,
+            render_mode=RenderMode.SVG,
+        )
+        # The composition path only reads .name/.link_peers/.cable per port
+        # (see rendered_layout._component_querysets) — it doesn't need a
+        # real FrontPort<->RearPort mapping, so these are independent.
+        RearPort.objects.create(device=self.device, name="Port 1", type="8p8c")
+        RearPort.objects.create(device=self.device, name="Port 2", type="8p8c")
+        FrontPort.objects.create(device=self.device, name="Port 1", type="8p8c")
+        FrontPort.objects.create(device=self.device, name="Port 2", type="8p8c")
+
+    def test_front_and_rear_faces_return_distinct_panels(self):
+        response = self.client.get(self._url())
+        data = response.json()
+        self.assertTrue(data["available"])
+        keys = {p["key"] for p in data["panels"]}
+        self.assertEqual(keys, {"front", "rear"})
+        for panel in data["panels"]:
+            self.assertTrue(
+                all(
+                    h["object_type"] in ("dcim.frontport", "dcim.rearport")
+                    for h in panel["hotspots"]
+                )
+            )
+            self.assertTrue(
+                all(h["trace_supported"] is False for h in panel["hotspots"])
+            )
+
+
+class VirtualChassisTests(RenderedLayoutTestBase):
+    def setUp(self):
+        super().setUp()
+        self._authenticate()
+        self._grant("dcim.view_device")
+        DeviceView.objects.create(
+            device_type=self.device_type,
+            grid_template_area="",
+            yaml_layout=SVG_YAML,
+            render_mode=RenderMode.SVG,
+        )
+
+    def test_virtual_chassis_produces_one_panel_set_per_member(self):
+        vc = VirtualChassis.objects.create(name="VC1")
+        self.device.virtual_chassis = vc
+        self.device.vc_position = 1
+        self.device.save()
+
+        member2 = Device.objects.create(
+            name="dev2",
+            device_type=self.device_type,
+            role=self.role,
+            site=self.site,
+            status="active",
+            virtual_chassis=vc,
+            vc_position=2,
+        )
+        self._make_interfaces(device=self.device)
+        self._make_interfaces(device=member2)
+
+        response = self.client.get(self._url())
+        data = response.json()
+        self.assertTrue(data["available"])
+        self.assertEqual(len(data["panels"]), 2)
+        keys = {p["key"] for p in data["panels"]}
+        self.assertTrue(all(k.startswith("member-") for k in keys))
+
+    def test_any_member_missing_device_view_fails_whole_response(self):
+        other_type = DeviceType.objects.create(
+            manufacturer=self.manufacturer,
+            model="Switch-NoView",
+            slug="switch-no-view",
+            u_height=1,
+        )
+        vc = VirtualChassis.objects.create(name="VC2")
+        self.device.virtual_chassis = vc
+        self.device.vc_position = 1
+        self.device.save()
+        Device.objects.create(
+            name="dev3",
+            device_type=other_type,
+            role=self.role,
+            site=self.site,
+            status="active",
+            virtual_chassis=vc,
+            vc_position=2,
+        )
+
+        response = self.client.get(self._url())
+        data = response.json()
+        self.assertFalse(data["available"])
+        self.assertEqual(data["reason"], "no_layout")
+
+
+class QueryCountTests(RenderedLayoutTestBase):
+    """Guards against N+1 regressions in the composition path."""
+
+    def setUp(self):
+        super().setUp()
+        self._authenticate()
+        self._grant("dcim.view_device")
+        DeviceView.objects.create(
+            device_type=self.device_type,
+            grid_template_area="",
+            yaml_layout=SVG_YAML,
+            render_mode=RenderMode.SVG,
+        )
+
+    def test_query_count_does_not_scale_with_interface_count(self):
+        ifaces_small = self._make_interfaces(count=4)
+        for i in range(0, 4, 2):
+            Cable(
+                a_terminations=[ifaces_small[i]],
+                b_terminations=[ifaces_small[i + 1]],
+                color="ff0000",
+            ).save()
+
+        with CaptureQueriesContext(connection) as small_ctx:
+            self.client.get(self._url())
+        small_count = len(small_ctx.captured_queries)
+
+        big_device = Device.objects.create(
+            name="dev-big",
+            device_type=DeviceType.objects.create(
+                manufacturer=self.manufacturer,
+                model="Switch40",
+                slug="switch40",
+                u_height=1,
+            ),
+            role=self.role,
+            site=self.site,
+            status="active",
+        )
+        DeviceView.objects.create(
+            device_type=big_device.device_type,
+            grid_template_area="",
+            yaml_layout=SVG_YAML.replace("count: 4", "count: 40"),
+            render_mode=RenderMode.SVG,
+        )
+        ifaces_big = self._make_interfaces(count=40, device=big_device)
+        for i in range(0, 40, 2):
+            Cable(
+                a_terminations=[ifaces_big[i]],
+                b_terminations=[ifaces_big[i + 1]],
+                color="ff0000",
+            ).save()
+
+        with CaptureQueriesContext(connection) as big_ctx:
+            self.client.get(self._url(big_device))
+        big_count = len(big_ctx.captured_queries)
+
+        # A handful of extra queries (pagination-free single object, cable
+        # trace prefetches) is fine; linear growth with interface count is
+        # the N+1 regression this test exists to catch.
+        self.assertLess(big_count, small_count + 10)

--- a/tests/test_layout_svg_renderer.py
+++ b/tests/test_layout_svg_renderer.py
@@ -24,12 +24,12 @@ from netbox_device_view.layout.renderers.svg import (
     GAP,
     PADDING,
     _abbreviate,
-    _cell_size,
-    _cell_xy,
-    _element_dims,
-    _svg_dims,
+    cell_size,
+    cell_xy,
+    element_dims,
     render,
     render_view_svg,
+    svg_dims,
 )
 
 # ---------------------------------------------------------------------------
@@ -62,15 +62,15 @@ def _attr(svg: str, attr: str) -> list[str]:
 class TestCoordinateHelpers:
     def test_cell_size_normal(self):
         canvas = CanvasConfig(cell_size=20)
-        assert _cell_size(canvas) == 20
+        assert cell_size(canvas) == 20
 
     def test_cell_size_zero_returns_default(self):
         canvas = CanvasConfig(cell_size=0)
-        assert _cell_size(canvas) == DEFAULT_CELL
+        assert cell_size(canvas) == DEFAULT_CELL
 
     def test_svg_dims_standard(self):
         canvas = CanvasConfig(columns=4, rows=2, cell_size=20)
-        w, h = _svg_dims(canvas)
+        w, h = svg_dims(canvas)
         expected_w = 4 * 20 + 3 * GAP + 2 * PADDING
         expected_h = 2 * 20 + 1 * GAP + 2 * PADDING
         assert w == expected_w
@@ -78,7 +78,7 @@ class TestCoordinateHelpers:
 
     def test_svg_dims_single_row(self):
         canvas = CanvasConfig(columns=6, rows=1, cell_size=20)
-        w, h = _svg_dims(canvas)
+        w, h = svg_dims(canvas)
         expected_w = 6 * 20 + 5 * GAP + 2 * PADDING
         expected_h = 1 * 20 + 0 * GAP + 2 * PADDING
         assert w == expected_w
@@ -86,19 +86,19 @@ class TestCoordinateHelpers:
 
     def test_cell_xy_first_cell(self):
         canvas = CanvasConfig(columns=4, rows=2, cell_size=20)
-        x, y = _cell_xy(1, 1, canvas)
+        x, y = cell_xy(1, 1, canvas)
         assert x == PADDING
         assert y == PADDING
 
     def test_cell_xy_second_col(self):
         canvas = CanvasConfig(columns=4, rows=2, cell_size=20)
-        x, y = _cell_xy(1, 2, canvas)
+        x, y = cell_xy(1, 2, canvas)
         assert x == PADDING + 20 + GAP
         assert y == PADDING
 
     def test_cell_xy_second_row(self):
         canvas = CanvasConfig(columns=4, rows=2, cell_size=20)
-        x, y = _cell_xy(2, 1, canvas)
+        x, y = cell_xy(2, 1, canvas)
         assert x == PADDING
         assert y == PADDING + 20 + GAP
 
@@ -107,7 +107,7 @@ class TestCoordinateHelpers:
         el = PlacedElement(
             kind=ElementKind.PORT, key="p1", row=1, col=1, row_span=1, col_span=1
         )
-        w, h = _element_dims(el, canvas)
+        w, h = element_dims(el, canvas)
         assert w == 20
         assert h == 20
 
@@ -116,7 +116,7 @@ class TestCoordinateHelpers:
         el = PlacedElement(
             kind=ElementKind.PORT, key="p1", row=1, col=1, row_span=2, col_span=3
         )
-        w, h = _element_dims(el, canvas)
+        w, h = element_dims(el, canvas)
         # 3 cols: 3*20 + 2*GAP
         assert w == 3 * 20 + 2 * GAP
         # 2 rows: 2*20 + 1*GAP


### PR DESCRIPTION
## Summary
- Adds `GET /api/plugins/device_view/devices/<id>/rendered-layout/` — a read-only, token-authenticated, versioned JSON endpoint that composes a device's SVG layout (structure, hotspot geometry, connection state, cable color, peer summaries) into one response, for API clients that shouldn't reimplement `ports.html`'s inline JS composition logic.
- SVG is built specifically for renderers with no CSS support and unreliable text layout (e.g. flutter_svg): no CSS classes, no `<text>`, colors baked in as explicit `fill` attributes.
- Handles: missing device (404), no view permission (403), object-scoped-out device (404, matching NetBox's own convention), no DeviceView configured, CSS-only/legacy DeviceView, invalid YAML, Virtual Chassis (one panel set per member), patch panels (front/rear as separate panels).
- Corrects two stale doc claims found while verifying this (`svg-renderer.md`, `virtual-chassis.md` both said "SVG unsupported for Virtual Chassis" — traced `prepare_svg()` and confirmed it already works when every member has an SVG-capable DeviceView).
- Full schema/permissions/compatibility docs: `docs/rendered-layout-api.md`.

## Test plan
- [x] `pytest tests/` — 211/211 passing (191 existing + 20 new in `tests/test_api_rendered_layout.py`, covering auth, object-permission scoping, all availability reasons, cable colors, VC multi-panel, patch panels, and a query-count regression guard)
- [x] `black --check` / `ruff check` clean
- [x] Live-verified against a real NetBox 4.6.8 devcontainer instance with a 4-port fixture (colored cable, no-color cable, disabled port) — response matched the documented schema exactly
